### PR TITLE
News section + backend news; make CI PR-only

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -6,12 +6,6 @@ on:
     paths:
       - 'backend/**'
       - '.github/workflows/backend-ci.yml'
-  # Also run after merges to main that touch backend/ or this workflow
-  push:
-    branches: [ main ]
-    paths:
-      - 'backend/**'
-      - '.github/workflows/backend-ci.yml'
 
 jobs:
   build-test:
@@ -35,29 +29,11 @@ jobs:
           cache: 'pip'                              # <- speed up installs
           cache-dependency-path: backend/requirements_api.txt  # <- EXACT file
 
-      # 3) Provide a non-secret .env if an example exists (prevents import crashes)
-      - name: Prepare .env
-        run: |
-          if [ -f .env.example ] && [ ! -f .env ]; then cp .env.example .env; fi
-
-      # 4) Install backend dependencies from YOUR exact file name
+      # 3) Install backend dependencies from YOUR exact file name
       - name: Install dependencies
         run: pip install -r requirements_api.txt
 
-      # 5) Smoke check: fail fast if the app entrypoint can’t import
-      - name: Import app.main
-        run: |
-          python - << 'PY'
-          import importlib, sys
-          try:
-              importlib.import_module('app.main')   # <- adjust only if your path differs
-              print("OK: import app.main")
-          except Exception as e:
-              print("FAIL:", e)
-              sys.exit(1)
-          PY
-
-      # 6) Run tests only if a tests/ folder exists (auto-skip otherwise)
+      # 4) Run tests only if a tests/ folder exists (auto-skip otherwise)
       - name: Run tests (if present)
         if: ${{ hashFiles('backend/tests/**') != '' }}
         run: pytest -q

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -7,12 +7,6 @@ on:
     paths:
       - 'frontend/**'
       - '.github/workflows/frontend-ci.yml'
-  # Also run after merges to main (sanity check)
-  push:
-    branches: [ main ]
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-ci.yml'
 
 # If multiple runs are triggered on the same branch, keep only the newest
 concurrency:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,8 @@ from .routers import leaguesPage
 from .routers import teamPage
 from .routers import matchDetailsPage
 from .routers import leagueModal
+from .routers import news
+
 
 
 # ─────────── logging config ───────────
@@ -96,3 +98,5 @@ app.include_router(leaguesPage.router)
 app.include_router(teamPage.router)
 app.include_router(matchDetailsPage.router)
 app.include_router(leagueModal.router)
+app.include_router(news.router)
+

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -1,0 +1,133 @@
+"""
+News feed routes
+────────────────
+GET /news        → newest first, optional tab filter, keyset pagination
+"""
+import logging
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+from base64 import urlsafe_b64encode, urlsafe_b64decode
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_session
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["news"])
+
+ALLOWED_TABS = {"transfers", "injuries", "matchreports"}
+
+# ───────────────────────────
+# Pydantic response models
+# ───────────────────────────
+class NewsItemOut(BaseModel):
+    article_id: str
+    tab: str
+    title: str
+    summary: Optional[str] = None
+    image_url: Optional[str] = None
+    source: str
+    url: str
+    published_at_utc: datetime
+
+class NewsPageOut(BaseModel):
+    items: List[NewsItemOut]
+    next_cursor: Optional[str] = None
+
+# ───────────────────────────
+# Cursor helpers (opaque)
+# ───────────────────────────
+def _encode_cursor(ts: datetime, article_id: str) -> str:
+    payload = {"ts": ts.astimezone(timezone.utc).isoformat(), "id": article_id}
+    return urlsafe_b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+
+def _decode_cursor(cursor: str) -> Tuple[datetime, str]:
+    try:
+        data = json.loads(urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8"))
+        ts = datetime.fromisoformat(data["ts"])
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return ts.astimezone(timezone.utc), data["id"]
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid cursor"
+        )
+
+# ───────────────────────────
+# Routes
+# ───────────────────────────
+@router.get("/news", response_model=NewsPageOut)
+async def list_news(
+    response: Response,
+    tab: Optional[str] = Query(None, description="transfers|injuries|matchreports"),
+    limit: int = Query(20, ge=1, le=50),
+    cursor: Optional[str] = Query(None),
+    db: AsyncSession = Depends(get_session),
+):
+    """
+    Returns newest articles. If `tab` is omitted, returns across all tabs.
+    Keyset pagination via `cursor` (opaque).
+    """
+    if tab is not None and tab not in ALLOWED_TABS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid tab: {tab!r}. Allowed: {sorted(ALLOWED_TABS)}",
+        )
+
+    params = {"limit": limit}
+    where_clauses = ["1=1"]
+    if tab:
+        where_clauses.append("tab = :tab")
+        params["tab"] = tab
+
+    if cursor:
+        cur_ts, cur_id = _decode_cursor(cursor)
+        where_clauses.append(
+            "(published_at_utc < :cur_ts OR (published_at_utc = :cur_ts AND article_id < :cur_id))"
+        )
+        params["cur_ts"] = cur_ts
+        params["cur_id"] = cur_id
+
+    sql = text(f"""
+        SELECT
+            article_id,
+            tab,
+            title,
+            summary,
+            image_url,
+            source,
+            url,
+            published_at_utc
+        FROM news
+        WHERE {' AND '.join(where_clauses)}
+        ORDER BY published_at_utc DESC, article_id DESC
+        LIMIT :limit
+    """)
+
+    try:
+        result = await db.execute(sql, params)
+        rows = list(result.mappings())
+    except SQLAlchemyError as err:
+        logger.exception("DB error in GET /news (tab=%s, limit=%s)", tab, limit)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error",
+        ) from err
+
+    items = [NewsItemOut(**row) for row in rows]
+
+    next_cursor = None
+    if len(items) == limit:
+        last = items[-1]
+        next_cursor = _encode_cursor(last.published_at_utc, last.article_id)
+
+    # Light caching; safe to add now
+    response.headers["Cache-Control"] = "public, max-age=60"
+
+    return NewsPageOut(items=items, next_cursor=next_cursor)

--- a/etl/src/blob/fetch_data/fetch_news.py
+++ b/etl/src/blob/fetch_data/fetch_news.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+fetch_news.py
+───────────────────────────────────────────────────────────────────────────────
+Fetch Guardian football news for three query shapes (transfers, injuries, match
+reports) and upload raw artifacts to Azure Blob Storage.
+
+Layout (per run; shared UTC second-stamp across tabs):
+raw/news/guardian/
+  search_football_transfers/     run_ts=YYYY-MM-DDTHH-MM-SS/{request.txt,params.json,response.json,_meta.json}
+  search_football_injuries/      run_ts=YYYY-MM-DDTHH-MM-SS/{...}
+  search_football_matchreports/  run_ts=YYYY-MM-DDTHH-MM-SS/{...}
+
+Fixed params for ALL tabs:
+  page-size=10, order-by=newest, show-fields=thumbnail,trailText,shortUrl,byline
+
+Tabs (FOOTBALL-ONLY):
+
+  transfers →
+    section=football
+    tag=football/football,tone/news,type/article,-tone/minutebyminute,-type/liveblog,-tone/comment,-tone/analysis,-tone/matchreports
+    q=(transfer terms) AND NOT (injury terms)
+    query-fields=headline
+
+  injuries  →
+    section=football
+    tag=football/football,tone/news,type/article,-tone/minutebyminute,-type/liveblog,-tone/comment,-tone/analysis,-tone/matchreports
+    q=(injury terms) AND NOT (noise terms incl. transfer/loan/etc.)
+    query-fields=headline
+
+  matchreports →
+    section=football
+    tag=football/football,tone/matchreports,type/article
+
+Secrets (NEVER written to blob):
+  from etl/config/credentials.py → NEWS_API_KEYS["api_news"], AZURE_STORAGE
+
+Run:
+  python etl/src/blob/fetch_data/fetch_news.py
+"""
+
+import os
+import sys
+import json
+import time
+import datetime as dt
+from urllib.parse import urlencode
+
+import requests
+from azure.storage.blob import BlobServiceClient, ContentSettings
+
+# ── credentials import ────────────────────────────────────────────────────────
+BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+sys.path.append(os.path.join(BASE, "config"))
+from credentials import NEWS_API_KEYS, AZURE_STORAGE  # type: ignore
+
+# ── constants ─────────────────────────────────────────────────────────────────
+RAW_CONTAINER = "raw"
+OUT_PREFIX    = "news/guardian"
+BASE_URL      = "https://content.guardianapis.com/search"
+GUARDIAN_KEY  = NEWS_API_KEYS["api_news"]
+
+COMMON = {
+    "order-by": "newest",
+    "show-fields": "thumbnail,trailText,shortUrl,byline",
+    "page-size": 10,
+}
+
+# FOOTBALL-ONLY queries (finalized)
+TABS = [
+    # Transfers: football news articles, exclude non-news/analysis/liveblogs/match reports
+    ("transfers", "search_football_transfers", {
+        "section": "football",
+        "tag": "football/football,tone/news,type/article,-tone/minutebyminute,-type/liveblog,-tone/comment,-tone/analysis,-tone/matchreports",
+        "q": "("
+              "transfer OR transfers OR loan OR loans OR \"on loan\" OR swap OR swaps OR fee OR fees "
+              "OR deal OR deals OR sign OR signs OR signed OR signing OR \"medical\" OR \"clause\" OR \"contract\""
+             ") AND NOT ("
+              "injury OR injuries OR injured OR \"ruled out\" OR \"out for\" OR hamstring OR groin OR ankle OR knee "
+              "OR ACL OR MCL OR Achilles OR concussion OR fracture OR fractured OR broken OR meniscus OR calf OR thigh "
+              "OR sprain OR tear"
+             ")",
+        "query-fields": "headline",
+    }),
+
+    # Injuries: football news articles, exclude non-news/analysis/liveblogs/match reports + transfer/loan noise
+    ("injuries", "search_football_injuries", {
+        "section": "football",
+        "tag": "football/football,tone/news,type/article,-tone/minutebyminute,-type/liveblog,-tone/comment,-tone/analysis,-tone/matchreports",
+        "q": "("
+              "injury OR injuries OR injured OR \"ruled out\" OR \"out for\" OR hamstring OR groin OR ankle OR knee "
+              "OR ACL OR MCL OR Achilles OR concussion OR fracture OR fractured OR broken OR meniscus OR calf OR thigh "
+              "OR sprain OR tear"
+             ") AND NOT ("
+              "crisis OR preview OR legal OR court OR owner OR lawsuit OR case OR dies OR death OR obituary OR riot OR police "
+              "OR derby OR fan OR loan OR transfer OR swap OR fee OR deal OR signs OR signed"
+             ")",
+        "query-fields": "headline",
+    }),
+
+    # Match reports: pure match report tone
+    ("matchreports", "search_football_matchreports", {
+        "section": "football",
+        "tag": "football/football,tone/matchreports,type/article",
+        # No q / query-fields needed; we want all match reports
+    }),
+]
+
+SLEEP_SEC   = 1.0
+TIMEOUT_SEC = 10
+
+
+def now_stamp_sec() -> str:
+    return dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def blob_service() -> BlobServiceClient:
+    return BlobServiceClient(
+        account_url=f"https://{AZURE_STORAGE['account_name']}.blob.core.windows.net",
+        credential=AZURE_STORAGE["access_key"],
+    )
+
+
+def upload_text(bs: BlobServiceClient, blob_path: str, text: str):
+    bs.get_blob_client(container=RAW_CONTAINER, blob=blob_path).upload_blob(
+        text,
+        overwrite=False,
+        content_settings=ContentSettings(content_type="text/plain; charset=utf-8"),
+    )
+    print(f"stored    {RAW_CONTAINER}/{blob_path}")
+
+
+def upload_json(bs: BlobServiceClient, blob_path: str, obj: dict):
+    bs.get_blob_client(container=RAW_CONTAINER, blob=blob_path).upload_blob(
+        json.dumps(obj, ensure_ascii=False, indent=2),
+        overwrite=False,
+        content_settings=ContentSettings(content_type="application/json"),
+    )
+    print(f"stored    {RAW_CONTAINER}/{blob_path}")
+
+
+def main() -> int:
+    run_ts = now_stamp_sec()
+    print(f"[fetch_news] run_ts={run_ts}")
+
+    bs = blob_service()
+    failures: list[tuple[str, str]] = []
+
+    for i, (tab, dir_name, extra) in enumerate(TABS):
+        base_dir = f"{OUT_PREFIX}/{dir_name}/run_ts={run_ts}"
+
+        # Real vs sanitized params/URL (never write the key)
+        params = dict(COMMON); params.update(extra); params["api-key"] = GUARDIAN_KEY
+        safe   = dict(COMMON); safe.update(extra);   safe["api-key"]   = "REDACTED"
+        url_safe = f"{BASE_URL}?{urlencode(safe)}"
+
+        t0 = time.time()
+        try:
+            r = requests.get(BASE_URL, params=params, timeout=TIMEOUT_SEC)
+            status = r.status_code
+            r.raise_for_status()
+            payload = r.json()
+            dur_ms = round((time.time() - t0) * 1000, 1)
+
+            if not isinstance(payload, dict) or "response" not in payload:
+                raise RuntimeError("Unexpected payload (missing 'response').")
+
+            upload_text(bs, f"{base_dir}/request.txt", url_safe)
+            upload_json(bs, f"{base_dir}/params.json", safe)
+            upload_json(bs, f"{base_dir}/response.json", payload)
+            upload_json(bs, f"{base_dir}/_meta.json", {
+                "fetched_at_utc": dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "http_status": status,
+                "duration_ms": dur_ms,
+                "source": "guardian",
+                "endpoint": "/search",
+                "tab": tab,
+            })
+
+        except Exception as e:
+            failures.append((tab, str(e)))
+            try:
+                upload_text(bs, f"{base_dir}/request.txt", url_safe)
+                upload_json(bs, f"{base_dir}/params.json", safe)
+                upload_json(bs, f"{base_dir}/_meta.json", {
+                    "fetched_at_utc": dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "http_status": None,
+                    "duration_ms": None,
+                    "source": "guardian",
+                    "endpoint": "/search",
+                    "tab": tab,
+                    "error": str(e),
+                })
+            except Exception:
+                pass
+
+        if i < len(TABS) - 1:
+            time.sleep(SLEEP_SEC)
+
+    if failures:
+        print("[fetch_news] Completed with errors:")
+        for tab, msg in failures:
+            print(f"  - {tab}: {msg}")
+        return 1
+
+    print("[fetch_news] Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/etl/src/blob/load_data/load_news.py
+++ b/etl/src/blob/load_data/load_news.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+load_stg_news.py
+────────────────────────────────────────────────────────────────────────────
+Loads the LATEST Guardian news batch per tab (transfers / injuries / matchreports)
+from Azure Blob raw artifacts into stg_news.
+
+Notes:
+  • No TRUNCATE here (handled elsewhere).
+  • Picks the lexicographically newest run_ts=... per tab by finding .../response.json.
+  • Normalizes: summary strips HTML, prefers fields.shortUrl over webUrl.
+  • Bulk upsert via execute_values for speed.
+
+Run:
+  source footysphere_venv/bin/activate
+  python etl/src/blob/load_data/load_stg_news.py
+"""
+
+# ───────────── Imports & helper-path setup ────────────────────────────────
+import os, sys, re, json, html
+from typing import Optional, Tuple, List
+from azure.storage.blob import BlobServiceClient
+from psycopg2.extras import execute_values, Json
+
+# add project helper dirs to PYTHONPATH
+sys.path.extend([
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../config")),
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")),
+])
+
+from credentials  import AZURE_STORAGE           # secrets (account + key)
+from get_db_conn  import get_db_connection       # returns psycopg2 connection
+
+RAW_CONTAINER = "raw"
+OUT_PREFIX    = "news/guardian"
+
+# tab -> directory name under OUT_PREFIX
+TAB_DIRS = {
+    "transfers":    "search_football_transfers",
+    "injuries":     "search_football_injuries",
+    "matchreports": "search_football_matchreports",
+}
+
+MANDATORY_KEYS = ("id", "webTitle", "webPublicationDate")
+
+# ─────────────── Blob helpers ─────────────────────────────────────────────
+def list_latest_run_ts_for_tab(bs: BlobServiceClient, tab_dir: str) -> Optional[Tuple[str, str]]:
+    """
+    Return (run_ts, base_dir) for the newest batch for a given tab dir,
+    where base_dir is like: news/guardian/<tab_dir>/run_ts=YYYY-MM-DDTHH-MM-SS
+    """
+    prefix = f"{OUT_PREFIX}/{tab_dir}/"
+    # List only response.json files; they're our "batch existence" signals.
+    blobs = bs.get_container_client(RAW_CONTAINER).list_blobs(name_starts_with=prefix)
+    candidates = []
+    for b in blobs:
+        name = b.name
+        if not name.endswith("/response.json"):
+            continue
+        # Expect .../run_ts=YYYY-MM-DDTHH-MM-SS/response.json
+        m = re.search(r"run_ts=([^/]+)/response\.json$", name)
+        if m:
+            run_ts = m.group(1)
+            # base_dir = path up to run_ts=... (without trailing file)
+            base_dir = name.rsplit("/", 1)[0]  # drop 'response.json'
+            candidates.append((run_ts, base_dir))
+
+    if not candidates:
+        return None
+    # run_ts is ISO-like; lexicographic max = newest
+    candidates.sort(key=lambda t: t[0])
+    return candidates[-1]
+
+
+def fetch_json_from_blob(bs: BlobServiceClient, blob_path: str) -> dict:
+    blob = bs.get_blob_client(RAW_CONTAINER, blob_path)
+    return json.loads(blob.download_blob().readall())
+
+# ─────────────── Transform helpers ────────────────────────────────────────
+def strip_html(text: Optional[str]) -> Optional[str]:
+    if not text:
+        return None
+    # fast tag-strip + unescape entities
+    return html.unescape(re.sub(r"<[^>]+>", "", text)).strip() or None
+
+
+def run_ts_to_iso_utc(run_ts: str) -> str:
+    """
+    Convert 'YYYY-MM-DDTHH-MM-SS' -> 'YYYY-MM-DDTHH:MM:SSZ'
+    """
+    date_part, time_part = run_ts.split("T", 1)
+    hh, mm, ss = time_part.split("-")
+    return f"{date_part}T{hh}:{mm}:{ss}Z"
+
+
+def rows_from_response(tab: str, response: dict, fetched_at_utc: Optional[str], fallback_run_ts: Optional[str]) -> List[tuple]:
+    """
+    Build rows for stg_news insert.
+    Returns list of tuples in the order of INSERT columns.
+    """
+    results = (response.get("response") or {}).get("results") or []
+    rows = []
+
+    # decide fetched_at_utc
+    fetched = fetched_at_utc or (run_ts_to_iso_utc(fallback_run_ts) if fallback_run_ts else None)
+
+    for item in results:
+        article_id = item.get("id")
+        title      = item.get("webTitle")
+        pub_utc    = item.get("webPublicationDate")
+        fields     = item.get("fields") or {}
+        url        = fields.get("shortUrl") or item.get("webUrl")
+        img        = fields.get("thumbnail")
+        summary    = strip_html(fields.get("trailText"))
+
+        is_valid = True
+        error_reason = None
+
+        for k in MANDATORY_KEYS:
+            if not item.get(k):
+                is_valid = False
+                error_reason = f"missing {k}"
+                break
+        if not url:
+            is_valid = False
+            error_reason = (error_reason + "; missing url") if error_reason else "missing url"
+
+        rows.append((
+            article_id,            # article_id
+            tab,                   # tab
+            title,                 # title
+            summary,               # summary
+            img,                   # image_url
+            "The Guardian",        # source
+            url,                   # url
+            pub_utc,               # published_at_utc (string OK; PG parses ISO)
+            fetched,               # fetched_at_utc (string ISO Z)
+            Json(item),                  # raw (JSONB)
+            is_valid,              # is_valid
+            error_reason           # error_reason
+        ))
+    return rows
+
+# ─────────────── Main loader ──────────────────────────────────────────────
+def main() -> None:
+    # 1) Connect to Postgres & Azure Blob
+    conn = get_db_connection()
+    cur  = conn.cursor()
+    bs   = BlobServiceClient(
+        account_url=f"https://{AZURE_STORAGE['account_name']}.blob.core.windows.net",
+        credential=AZURE_STORAGE["access_key"],
+    )
+
+    total_rows = 0
+    per_tab_counts = {}
+
+    try:
+        all_rows = []
+
+        for tab, tab_dir in TAB_DIRS.items():
+            latest = list_latest_run_ts_for_tab(bs, tab_dir)
+            if not latest:
+                print(f"[{tab}] No batches found under {OUT_PREFIX}/{tab_dir}/ — skipping.")
+                continue
+
+            run_ts, base_dir = latest
+            # required files
+            resp_key = f"{base_dir}/response.json"
+            meta_key = f"{base_dir}/_meta.json"
+
+            try:
+                response_json = fetch_json_from_blob(bs, resp_key)
+            except Exception as e:
+                print(f"[{tab}] ERROR reading {resp_key}: {e}")
+                continue
+
+            fetched_at_utc = None
+            try:
+                meta_json = fetch_json_from_blob(bs, meta_key)
+                fetched_at_utc = (meta_json or {}).get("fetched_at_utc")
+            except Exception:
+                # tolerate missing _meta.json; derive from run_ts
+                fetched_at_utc = None
+
+            rows = rows_from_response(tab, response_json, fetched_at_utc, run_ts)
+            per_tab_counts[tab] = len(rows)
+            all_rows.extend(rows)
+
+        if not all_rows:
+            print("load_stg_news: nothing to insert.")
+            cur.close(); conn.close(); return
+
+        # 2) Bulk UPSERT
+        insert_sql = """
+            INSERT INTO stg_news (
+                article_id, tab, title, summary, image_url, source, url,
+                published_at_utc, fetched_at_utc, raw, is_valid, error_reason
+            )
+            VALUES %s
+            ON CONFLICT (article_id) DO UPDATE SET
+                tab              = EXCLUDED.tab,
+                title            = EXCLUDED.title,
+                summary          = EXCLUDED.summary,
+                image_url        = EXCLUDED.image_url,
+                source           = EXCLUDED.source,
+                url              = EXCLUDED.url,
+                published_at_utc = EXCLUDED.published_at_utc,
+                fetched_at_utc   = EXCLUDED.fetched_at_utc,
+                raw              = EXCLUDED.raw,
+                is_valid         = EXCLUDED.is_valid,
+                error_reason     = EXCLUDED.error_reason;
+        """
+
+        execute_values(cur, insert_sql, all_rows, page_size=500)
+        conn.commit()
+
+        total_rows = len(all_rows)
+        print(f"load_stg_news: inserted/updated {total_rows} rows "
+              f"(transfers={per_tab_counts.get('transfers',0)}, "
+              f"injuries={per_tab_counts.get('injuries',0)}, "
+              f"matchreports={per_tab_counts.get('matchreports',0)}).")
+
+    except Exception as err:
+        conn.rollback()
+        print(f"load_stg_news: ERROR → {err}")
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+
+# ─────────────── Entrypoint ───────────────────────────────────────────────
+if __name__ == "__main__":
+    main()

--- a/etl/src/proc_calls/check_stg_news.py
+++ b/etl/src/proc_calls/check_stg_news.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+# Add your DB connection script path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+from get_db_conn import get_db_connection
+
+PROC_NAME = "check_stg_news"  # stored PROCEDURE name
+
+def check_stg_news():
+    """
+    Calls stored procedure check_stg_news(),
+    captures RAISE NOTICE messages from conn.notices, and prints them.
+    """
+    conn = get_db_connection()
+    cur = conn.cursor()
+    try:
+        # Ensure we get NOTICE-level messages
+        cur.execute("SET client_min_messages = 'NOTICE';")
+
+        # Clear any leftover notices
+        conn.notices.clear()
+
+        print(f"Calling procedure `{PROC_NAME}`...")
+        cur.execute(f"CALL {PROC_NAME}();")
+        conn.commit()
+
+        print(f"Procedure `{PROC_NAME}` executed successfully.")
+
+        # Print DB NOTICEs
+        if conn.notices:
+            for notice in conn.notices:
+                print("NOTICE:", notice.strip())
+        else:
+            print("No NOTICE messages from the DB.")
+
+        print("Validation of stg_news complete. Check `data_load_errors` for any issues.")
+    except Exception as e:
+        conn.rollback()
+        print(f"Error calling `{PROC_NAME}`: {e}")
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+if __name__ == "__main__":
+    check_stg_news()

--- a/etl/src/proc_calls/update_news.py
+++ b/etl/src/proc_calls/update_news.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import os
+import sys
+import re
+
+# Add your DB connection script path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+from get_db_conn import get_db_connection
+
+PROC_NAME = "update_news"  # stored PROCEDURE name
+
+def run_update_news():
+    """
+    Calls stored procedure update_news(), captures RAISE NOTICE messages,
+    and prints a short summary of inserts/updates.
+    """
+    conn = get_db_connection()
+    cur = conn.cursor()
+    try:
+        # Ensure we get NOTICE-level messages
+        cur.execute("SET client_min_messages = 'NOTICE';")
+
+        # Clear any leftover notices
+        conn.notices.clear()
+
+        print(f"Calling procedure `{PROC_NAME}`...")
+        cur.execute(f"CALL {PROC_NAME}();")
+        conn.commit()
+        print(f"Procedure `{PROC_NAME}` executed successfully.")
+
+        inserts = None
+        updates = None
+
+        # Print DB NOTICEs and extract counts if present
+        if conn.notices:
+            for notice in conn.notices:
+                msg = notice.strip()
+                print("NOTICE:", msg)
+                m = re.search(r'update_news:\s*inserted=(\d+),\s*updated=(\d+)', msg, re.IGNORECASE)
+                if m:
+                    inserts = int(m.group(1))
+                    updates = int(m.group(2))
+        else:
+            print("No NOTICE messages from the DB.")
+
+        if inserts is not None and updates is not None:
+            print(f"Summary — inserts: {inserts}, updates: {updates}")
+        else:
+            print("Summary — counts not found in NOTICE output.")
+
+    except Exception as e:
+        conn.rollback()
+        print(f"Error calling `{PROC_NAME}`: {e}")
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+if __name__ == "__main__":
+    run_update_news()

--- a/etl/src/tables/prod_tables/create_fixtures_table.py
+++ b/etl/src/tables/prod_tables/create_fixtures_table.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # Add your test_scripts dir for get_db_conn
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/prod_tables/create_league_catalog_table.py
+++ b/etl/src/tables/prod_tables/create_league_catalog_table.py
@@ -9,7 +9,7 @@ import sys
 
 # Add test_scripts dir to import get_db_connection
 sys.path.append(
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts"))
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts"))
 )
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/prod_tables/create_league_directory_table.py
+++ b/etl/src/tables/prod_tables/create_league_directory_table.py
@@ -10,7 +10,7 @@ import sys
 
 # Add test_scripts dir to import get_db_connection
 sys.path.append(
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts"))
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts"))
 )
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/prod_tables/create_league_seasons_table.py
+++ b/etl/src/tables/prod_tables/create_league_seasons_table.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # Add the `test_scripts` directory to sys.path for imports
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/prod_tables/create_leagues_table.py
+++ b/etl/src/tables/prod_tables/create_leagues_table.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # Add the `test_scripts` directory to sys.path for imports
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/prod_tables/create_match_events_table.py
+++ b/etl/src/tables/prod_tables/create_match_events_table.py
@@ -4,7 +4,7 @@ Creates the production match_events table + indexes.
 """
 import os, sys
 sys.path.append(os.path.abspath(os.path.join(
-    os.path.dirname(__file__), "../../test_scripts")))
+    os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 DDL = """

--- a/etl/src/tables/prod_tables/create_match_statistics_table.py
+++ b/etl/src/tables/prod_tables/create_match_statistics_table.py
@@ -1,6 +1,6 @@
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 def create_match_statistics_table():

--- a/etl/src/tables/prod_tables/create_news_table.py
+++ b/etl/src/tables/prod_tables/create_news_table.py
@@ -1,0 +1,84 @@
+import os
+import sys
+
+# Add your test_scripts dir for get_db_conn
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
+from get_db_conn import get_db_connection
+
+
+DDL_DROP_VIEW = "DROP VIEW IF EXISTS vw_news_by_tab_latest50;"
+
+DDL_TABLE_AND_INDEXES = """
+CREATE TABLE IF NOT EXISTS news (
+    article_id        TEXT PRIMARY KEY,
+    tab               TEXT NOT NULL CHECK (tab IN ('transfers','injuries','matchreports')),
+
+    title             TEXT NOT NULL,
+    summary           TEXT,
+    image_url         TEXT,
+    source            TEXT NOT NULL DEFAULT 'The Guardian',
+    url               TEXT NOT NULL,
+    published_at_utc  TIMESTAMPTZ NOT NULL,
+
+    -- Audit (DB-level)
+    load_date         TIMESTAMPTZ(0) NOT NULL DEFAULT NOW(),
+    upd_date          TIMESTAMPTZ(0) NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_news_url ON news (url);
+CREATE INDEX IF NOT EXISTS ix_news_tab_published ON news (tab, published_at_utc DESC);
+"""
+
+# Remove legacy lineage columns if they still exist
+DDL_REMOVE_LINEAGE_COLS = """
+ALTER TABLE IF EXISTS news
+  DROP COLUMN IF EXISTS first_seen_utc,
+  DROP COLUMN IF EXISTS last_seen_utc;
+"""
+
+DDL_TRIGGER = """
+-- Keep upd_date fresh on UPDATEs
+CREATE OR REPLACE FUNCTION trg_news_set_upd_date()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.upd_date := NOW();
+  RETURN NEW;
+END$$;
+
+DROP TRIGGER IF EXISTS set_upd_date_news ON news;
+CREATE TRIGGER set_upd_date_news
+BEFORE UPDATE ON news
+FOR EACH ROW EXECUTE FUNCTION trg_news_set_upd_date();
+"""
+
+DDL_VIEW = """
+CREATE OR REPLACE VIEW vw_news_by_tab_latest50 AS
+SELECT *
+FROM (
+  SELECT n.*, ROW_NUMBER() OVER (PARTITION BY tab ORDER BY published_at_utc DESC) AS rn
+  FROM news n
+) t
+WHERE rn <= 50;
+"""
+
+def create_news():
+    try:
+        conn = get_db_connection()
+        with conn, conn.cursor() as cur:
+            # 1) Drop the view if present so we can alter the table shape safely
+            cur.execute(DDL_DROP_VIEW)
+            # 2) Ensure table + indexes exist (without lineage columns)
+            cur.execute(DDL_TABLE_AND_INDEXES)
+            # 3) Remove lineage columns if they exist from older deployments
+            cur.execute(DDL_REMOVE_LINEAGE_COLS)
+            # 4) Recreate trigger
+            cur.execute(DDL_TRIGGER)
+            # 5) Recreate the view
+            cur.execute(DDL_VIEW)
+        print("Created/updated `news`, trigger, and `vw_news_by_tab_latest50` (no lineage columns).")
+    except Exception as e:
+        print(f"Error creating/updating `news` objects: {e}")
+        raise
+
+if __name__ == "__main__":
+    create_news()

--- a/etl/src/tables/prod_tables/create_player_season_stats_table.py
+++ b/etl/src/tables/prod_tables/create_player_season_stats_table.py
@@ -1,6 +1,6 @@
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 def create_player_season_stats_table():

--- a/etl/src/tables/prod_tables/create_player_stats_load_state_table.py
+++ b/etl/src/tables/prod_tables/create_player_stats_load_state_table.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # Add the `test_scripts` directory to sys.path for imports
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/prod_tables/create_players_table.py
+++ b/etl/src/tables/prod_tables/create_players_table.py
@@ -1,6 +1,6 @@
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 def create_players_table():

--- a/etl/src/tables/prod_tables/create_standings_table.py
+++ b/etl/src/tables/prod_tables/create_standings_table.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 # Add your get_db_conn path
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection  # expects a psycopg2-style connection
 
 DDL_STATEMENTS = [

--- a/etl/src/tables/prod_tables/create_team_ingest_status_table.py
+++ b/etl/src/tables/prod_tables/create_team_ingest_status_table.py
@@ -1,7 +1,7 @@
 # create_team_ingest_status_table.py
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/prod_tables/create_team_league_seasons_table.py
+++ b/etl/src/tables/prod_tables/create_team_league_seasons_table.py
@@ -1,7 +1,7 @@
 # create_team_league_seasons_table.py
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/prod_tables/create_teams_table.py
+++ b/etl/src/tables/prod_tables/create_teams_table.py
@@ -1,7 +1,7 @@
 # create_teams_table.py
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/prod_tables/create_venues_table.py
+++ b/etl/src/tables/prod_tables/create_venues_table.py
@@ -1,7 +1,7 @@
 # create_venues_table.py
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/stg_tables/create_data_load_errors_table.py
+++ b/etl/src/tables/stg_tables/create_data_load_errors_table.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # Add your test_scripts dir for get_db_conn
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/stg_tables/create_stg_fixtures_table.py
+++ b/etl/src/tables/stg_tables/create_stg_fixtures_table.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # Add the `test_scripts` dir for get_db_conn
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/stg_tables/create_stg_match_events_table.py
+++ b/etl/src/tables/stg_tables/create_stg_match_events_table.py
@@ -5,7 +5,7 @@ Run once (or safely re‑run) after you have get_db_conn().
 """
 import os, sys
 sys.path.append(os.path.abspath(os.path.join(
-    os.path.dirname(__file__), "../../test_scripts")))
+    os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 DDL = """

--- a/etl/src/tables/stg_tables/create_stg_match_statistics_table.py
+++ b/etl/src/tables/stg_tables/create_stg_match_statistics_table.py
@@ -1,6 +1,6 @@
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 def create_stg_match_statistics_table():

--- a/etl/src/tables/stg_tables/create_stg_news_table.py
+++ b/etl/src/tables/stg_tables/create_stg_news_table.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+# Add your test_scripts dir for get_db_conn
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
+from get_db_conn import get_db_connection
+
+
+DDL = """
+CREATE TABLE IF NOT EXISTS stg_news (
+    article_id        TEXT PRIMARY KEY,                               -- Guardian "id"
+    tab               TEXT NOT NULL CHECK (tab IN ('transfers','injuries','matchreports')),
+
+    title             TEXT NOT NULL,                                  -- webTitle
+    summary           TEXT,                                           -- stripped fields.trailText
+    image_url         TEXT,                                           -- fields.thumbnail
+    source            TEXT NOT NULL DEFAULT 'The Guardian',
+    url               TEXT NOT NULL,                                  -- fields.shortUrl else webUrl
+    published_at_utc  TIMESTAMPTZ NOT NULL,                           -- webPublicationDate (UTC)
+    fetched_at_utc    TIMESTAMPTZ NOT NULL,                           -- our fetch time (UTC)
+
+    raw               JSONB,                                          -- original item payload
+
+    is_valid          BOOLEAN DEFAULT TRUE,
+    error_reason      TEXT,
+    load_timestamp    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ix_stg_news_tab_published
+    ON stg_news (tab, published_at_utc DESC);
+"""
+
+
+def create_stg_news_table():
+    try:
+        conn = get_db_connection()
+        with conn, conn.cursor() as cur:
+            cur.execute(DDL)
+        print("Created `stg_news` (tabs: transfers, injuries, matchreports).")
+    except Exception as e:
+        print(f"Error creating `stg_news`: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    create_stg_news_table()

--- a/etl/src/tables/stg_tables/create_stg_player_seasons_stats_table.py
+++ b/etl/src/tables/stg_tables/create_stg_player_seasons_stats_table.py
@@ -1,6 +1,6 @@
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 def create_stg_player_season_stats_table():

--- a/etl/src/tables/stg_tables/create_stg_players_table.py
+++ b/etl/src/tables/stg_tables/create_stg_players_table.py
@@ -1,6 +1,6 @@
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 def create_stg_players_table():

--- a/etl/src/tables/stg_tables/create_stg_standing_table.py
+++ b/etl/src/tables/stg_tables/create_stg_standing_table.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 
 from get_db_conn import get_db_connection
 

--- a/etl/src/tables/stg_tables/create_stg_teams_table.py
+++ b/etl/src/tables/stg_tables/create_stg_teams_table.py
@@ -1,6 +1,6 @@
 # create_stg_teams_table.py
 import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../test_scripts")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 def create_stg_teams_table():

--- a/etl/src/tables/stg_tables/create_stg_venues_table.py
+++ b/etl/src/tables/stg_tables/create_stg_venues_table.py
@@ -11,7 +11,7 @@ Run once to create the scratch-pad table `stg_venues` and its indexes.
 
 import os, sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                             "../../test_scripts")))
+                                             "../../../test_scripts")))
 from get_db_conn import get_db_connection
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,17 +2,18 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import HomePage from "./pages/homePage/HomePage";
 import LeaguePage from "./pages/leaguePage/LeaguePage";
 import HealthTest from "./pages/HealthTest";
-import TeamPage from "./pages/teamPage/TeamPage"; // NEW
+import TeamPage from "./pages/teamPage/TeamPage";
 import MatchDetailsPage from "./pages/matchDetailsPage/MatchDetailsPage";
-
+import NewsPage from "./pages/newsPage/NewsPage"; 
 
 export default function App() {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/news" element={<NewsPage />} /> 
         <Route path="/league/:leagueId" element={<LeaguePage />} />
-        <Route path="/teams/:teamId" element={<TeamPage />} /> 
+        <Route path="/teams/:teamId" element={<TeamPage />} />
         <Route path="/match/:matchId" element={<MatchDetailsPage />} />
         <Route path="/health-test" element={<HealthTest />} />
       </Routes>

--- a/frontend/src/pages/homePage/HomePage.jsx
+++ b/frontend/src/pages/homePage/HomePage.jsx
@@ -10,6 +10,7 @@ import LeagueModal from "./LeagueModal";
 
 import PopularLeagues from "./PopularLeagues";
 import TodaysMatches from "./TodaysMatches";
+import News from "./News"; // ← NEW
 
 // Helper: try multiple endpoints safely
 async function firstPopularThatWorks(urls) {
@@ -116,6 +117,9 @@ export default function HomePage() {
           matchesByLeague={matchesByLeague}
           loading={loadingMatches}
         />
+
+        {/* ===== News section (below Today's Matches) ===== */}
+        <News />
       </main>
 
       <Footer />

--- a/frontend/src/pages/homePage/NavBar.jsx
+++ b/frontend/src/pages/homePage/NavBar.jsx
@@ -5,6 +5,7 @@ import "./styles/navBar.css";
 export default function NavBar() {
   const { pathname } = useLocation();
   const isHome = pathname === "/";
+  const isNews = pathname.startsWith("/news"); // ← NEW
 
   return (
     <header className="nb">
@@ -12,25 +13,26 @@ export default function NavBar() {
         {/* Brand */}
         <Link to="/" className="nb__brand" aria-label="FootySphere home">
           <span className="nb__logo-wrap">
-            {/* transparent PNG sits on a colored chip so it’s visible */}
-            <img
-              src="/logo.png"   // /public/logo.png
-              alt=""
-              className="nb__logo-img"
-              width={20}
-              height={20}
-            />
+            <img src="/logo.png" alt="" className="nb__logo-img" width={20} height={20} />
           </span>
           <span className="nb__name">FootySphere</span>
         </Link>
 
-        {/* Primary nav (News removed) */}
+        {/* Primary nav */}
         <nav className="nb__nav" aria-label="Primary">
           <Link to="/" className={`nb__btn ${isHome ? "is-active" : ""}`}>
             <svg className="nb__icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
               <path d="M10 1.25l2.18 5.38 5.82.18-4.6 3.68 1.64 5.61L10 13.7 4.96 16.1l1.64-5.61-4.6-3.68 5.82-.18L10 1.25z"/>
             </svg>
             <span>Leagues</span>
+          </Link>
+
+          {/* NEW: News */}
+          <Link to="/news" className={`nb__btn ${isNews ? "is-active" : ""}`}>
+            <svg className="nb__icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+              <path d="M4 5h12a2 2 0 0 1 2 2v10h1a1 1 0 0 0 1-1V8h-2V7a3 3 0 0 0-3-3H4a1 1 0 1 0 0 2Zm0 3h12v9a2 2 0 0 1-2 2H5a3 3 0 0 1-3-3V8h2v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V8H4Zm1 3h8v2H5v-2Zm0 3h8v2H5v-2Z"/>
+            </svg>
+            <span>News</span>
           </Link>
         </nav>
       </div>

--- a/frontend/src/pages/homePage/News.jsx
+++ b/frontend/src/pages/homePage/News.jsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { FaNewspaper } from "react-icons/fa";
+import "./styles/news.css";
+
+const API = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/+$/, "");
+const PREVIEW_COUNT = 3;
+
+// tiny helpers
+function timeAgo(isoUtc) {
+  try {
+    const d = new Date(isoUtc);
+    const s = Math.max(0, (Date.now() - d.getTime()) / 1000);
+    if (s < 60) return "just now";
+    const m = s / 60, h = m / 60, d2 = h / 24;
+    if (m < 60) return `${Math.floor(m)}m ago`;
+    if (h < 24) return `${Math.floor(h)}h ago`;
+    return `${Math.floor(d2)}d ago`;
+  } catch { return ""; }
+}
+function stripTags(html = "") {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  return (tmp.textContent || tmp.innerText || "").trim();
+}
+// deterministic daily selection (stable for a given UTC day)
+function pickDaily(items, count) {
+  if (!Array.isArray(items) || items.length <= count) return items || [];
+  const key = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  const step = 7; // small coprime-ish step
+  const out = [];
+  let idx = hash % items.length;
+  const used = new Set();
+  while (out.length < count) {
+    if (!used.has(idx)) {
+      out.push(items[idx]);
+      used.add(idx);
+    }
+    idx = (idx + step) % items.length;
+  }
+  return out;
+}
+
+export default function News() {
+  const [items, setItems] = useState([]);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const abortRef = useRef(null);
+
+  useEffect(() => {
+    if (abortRef.current) abortRef.current.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    (async () => {
+      try {
+        setError("");
+        // grab a small pool (20 newest across all tabs), then pick 3 deterministically
+        const res = await fetch(`${API}/news?limit=20`, { signal: ac.signal });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        const pool = Array.isArray(data.items) ? data.items : [];
+        setItems(pickDaily(pool, PREVIEW_COUNT));
+      } catch (e) {
+        if (e.name !== "AbortError") setError("Failed to load news preview.");
+      } finally {
+        if (abortRef.current === ac) abortRef.current = null;
+        setLoaded(true);
+      }
+    })();
+
+    return () => ac.abort();
+  }, [API]);
+
+  const hasAny = useMemo(() => (items || []).length > 0, [items]);
+
+  return (
+    <section id="news-preview" className="section-block">
+      <div className="section-header">
+        <div className="section-icon-box news-icon-box">
+          <FaNewspaper className="section-icon news-icon" />
+        </div>
+        <h2 className="section-title">News</h2>
+      </div>
+
+      {!loaded && !error && <p className="muted">Loading news…</p>}
+      {error && <p className="muted">{error}</p>}
+
+      {hasAny && (
+        <div className="news-preview-grid">
+          {items.map((it) => (
+            <article key={it.article_id} className="news-card tile">
+              {it.image_url ? (
+                <a
+                  href={it.url}
+                  className="news-thumb"
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={it.title}
+                >
+                  <img src={it.image_url} alt="" loading="lazy" />
+                </a>
+              ) : (
+                <div className="news-thumb news-thumb--empty" />
+              )}
+
+              <div className="news-body">
+                <h3 className="news-title">
+                  <a href={it.url} target="_blank" rel="noreferrer">
+                    {it.title}
+                  </a>
+                </h3>
+
+                <div className="news-meta">
+                  <span className="news-source">{it.source || "Source"}</span>
+                  <span className="news-dot">•</span>
+                  <time dateTime={it.published_at_utc}>{timeAgo(it.published_at_utc)}</time>
+                  {it.tab && (
+                    <>
+                      <span className="news-dot">•</span>
+                      <span className="news-tabchip">{it.tab}</span>
+                    </>
+                  )}
+                </div>
+
+                {it.summary && (
+                  <p className="news-summary clamp-3">{stripTags(it.summary)}</p>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+
+      <div className="view-more-container">
+        <Link to="/news" className="view-more-button">
+          View all news
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/homePage/styles/news.css
+++ b/frontend/src/pages/homePage/styles/news.css
@@ -1,0 +1,73 @@
+/* ===== Home: News Preview ===== */
+#news-preview{
+  --grid-gap: 20px;
+  --card-radius: 14px;
+  --thumb-ratio: 56.25%; /* 16:9 */
+}
+
+/* Grid: exactly 3 on desktop, responsive down */
+.news-preview-grid{
+  display:grid;
+  grid-template-columns: repeat(3, minmax(0,1fr));
+  gap: var(--grid-gap);
+}
+@media (max-width: 1200px){
+  .news-preview-grid{ grid-template-columns: repeat(2, minmax(0,1fr)); }
+}
+@media (max-width: 700px){
+  .news-preview-grid{ grid-template-columns: 1fr; }
+}
+
+/* Card (reuses .tile surface from homePage.css) */
+.news-card{
+  display:flex; flex-direction:column;
+  border-radius: var(--card-radius);
+  overflow:hidden;
+}
+
+/* Thumbnail */
+.news-thumb{
+  display:block; position:relative; width:100%;
+  padding-top: var(--thumb-ratio);
+  background:rgba(255,255,255,.04);
+  border-bottom:1px solid rgba(255,255,255,.08);
+}
+.news-thumb img{
+  position:absolute; inset:0; width:100%; height:100%;
+  object-fit:cover; display:block;
+}
+.news-thumb--empty{
+  display:block; height:0; padding-top: var(--thumb-ratio);
+  background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+}
+
+/* Body */
+.news-body{ padding:.8rem .9rem 1rem; display:flex; flex-direction:column; gap:.4rem; }
+.news-title{
+  margin:0; font-size:1.02rem; line-height:1.22; font-weight:800; color:#fff;
+}
+.news-title a{ color:inherit; text-decoration:none; }
+.news-title a:hover{ text-decoration:underline; }
+
+.news-meta{
+  display:flex; align-items:center; gap:.4rem;
+  font-size:.78rem; color:#aeb7c4;
+}
+.news-source{ font-weight:700; }
+.news-dot{ opacity:.6; }
+.news-tabchip{
+  text-transform:capitalize;
+  background:rgba(255,255,255,.06);
+  border:1px solid rgba(255,255,255,.12);
+  padding:.08rem .38rem; border-radius:999px; font-size:.72rem;
+}
+
+.news-summary{
+  color:#cfd6e2; font-size:.9rem; line-height:1.35;
+}
+
+/* Clamp (Chromium/WebKit) */
+.clamp-3{
+  display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical;
+  overflow:hidden;
+}

--- a/frontend/src/pages/homePage/styles/todaysMatches.css
+++ b/frontend/src/pages/homePage/styles/todaysMatches.css
@@ -1,218 +1,190 @@
-/* ===== Today's Matches — 2 content rails + optional right search rail ===== */
+/* ===== Today's Matches — Masonry, fixed center time, full wrapping (no cuts) ===== */
 
 /* Tunables */
 #today{
-  --w-2cols: 670px;      /* width of each content rail */
-  --center-col: 96px;    /* fixed time/status column */
-  --col-gap: 24px;       /* gap between columns */
-  --row-gap: 18px;       /* vertical gap between league blocks */
-  --rail-width: 340px;   /* right search rail width */
+  --w-2cols: 670px;       /* each content rail */
+  --col-gap: 24px;        /* gap between rails */
+  --row-gap: 18px;        /* vertical gap between league blocks */
+  --rail-width: 340px;    /* right search rail */
+
+  /* Center time column: fixed width (fits "08:00 PM") */
+  --center-col-fixed: 10ch;
+
+  /* Crest + text */
+  --crest-box: 36px;
+  --crest-radius: 10px;
+  --text-100: #e5e7eb;
+  --text-200: #cbd5e1;
 }
 
 /* ===== Layout wrapper: content + (optional) right rail ===== */
-.today-layout{
-  display:flex;
-  align-items:flex-start;
-  gap:var(--col-gap);
-  margin-top:.6rem;
-}
+.today-layout{ display:flex; align-items:flex-start; gap:var(--col-gap); margin-top:.6rem; }
+.content-zone{ width: calc(var(--w-2cols) * 2 + var(--col-gap)); }
+.today-rail{ width: var(--rail-width); flex:0 0 var(--rail-width); margin-top:0; }
+.rail-sticky{ position:sticky; top:0; }
 
-/* Content zone preserves your 2-rail grid exactly */
-.content-zone{
-  width: calc(var(--w-2cols) * 2 + var(--col-gap));
-}
-
-/* Right search rail */
-.today-rail{
-  width: var(--rail-width);
-  flex: 0 0 var(--rail-width);
-  margin-top: 0; /* align with top of matches */
-}
-.rail-sticky{
-  position: sticky;
-  top: 0;        /* no extra offset */
-}
-
-/* Collapse to single column on smaller screens (rail hidden) */
-@media (max-width: 1100px){
+@media (max-width:1100px){
   .today-layout{ display:block; }
   .content-zone{ width:100%; }
   .today-rail{ display:none; }
 }
 
-/* ===== Your original 2-rail grid (unchanged when not filtering) ===== */
-.todays-leagues-grid{
-  display:grid;
-  grid-template-columns: repeat(2, var(--w-2cols));
-  column-gap: var(--col-gap);
-  row-gap: var(--row-gap);
-  justify-content:start;    /* align rails under the header */
-  align-items:start;
+/* ===== League rail uses CSS columns for masonry (no big holes) ===== */
+.todays-leagues-grid{ display:block; column-count:2; column-gap:var(--col-gap); }
+.todays-leagues-grid.is-filtering{ display:block; column-count:2; column-gap:var(--col-gap); }
+@media (max-width:1100px){
+  .todays-leagues-grid,
+  .todays-leagues-grid.is-filtering{ column-count:1; }
 }
 
-/* Mobile/tablet: single rail */
-@media (max-width: 768px){
-  .todays-leagues-grid{
-    grid-template-columns: 1fr;
-    column-gap: 0;
-    row-gap: var(--row-gap);
-  }
+/* Each league block behaves as a masonry item — CLIPPED to its radius */
+.league-block{
+  display:inline-block;
+  width:100%;
+  margin:0 0 var(--row-gap);
+  padding:0;
+  overflow:hidden;                 /* clip child hovers to rounded corners */
+  border-radius:14px;              /* match your tile curve */
+  break-inside:avoid;
+  -webkit-column-break-inside:avoid;
+  page-break-inside:avoid;
+  isolation:isolate;
+  background-clip:padding-box;
+  transform:translateZ(0);         /* Safari seam fix */
 }
+.league-block.tile{ margin:0 0 var(--row-gap); }
 
-/* ===== Remove big gaps when filtering: 2-col masonry only while filtering ===== */
-.todays-leagues-grid.is-filtering{
-  display: block;                     /* disable grid */
-  column-count: 2;                    /* still two columns */
-  column-gap: var(--col-gap);
-}
-@media (max-width: 1100px){
-  .todays-leagues-grid.is-filtering{ column-count: 1; }
-}
-.todays-leagues-grid.is-filtering .league-block{
-  display: inline-block;
-  width: 100%;
-  margin: 0 0 var(--row-gap);
-  break-inside: avoid;
-  -webkit-column-break-inside: avoid;
-  page-break-inside: avoid;
-}
-
-/* ===== Cards (unchanged visuals) ===== */
-.league-block{ padding:0; overflow:hidden; }
-
+/* ===== Group header (rounded at the top) ===== */
 .group-header{
   display:flex; align-items:center; gap:.42rem;
   padding:.40rem .8rem;
   background:rgba(255,255,255,.04);
   border-bottom:1px solid rgba(255,255,255,.08);
-  border-radius:0;
   margin:0;
+  border-top-left-radius:inherit;
+  border-top-right-radius:inherit;
 }
 .group-dot{ width:6px; height:6px; border-radius:999px; background:#60a5fa; display:inline-block; }
 .group-title{ color:#fff; font-size:.84rem; font-weight:800; letter-spacing:.01rem; }
 
+/* ===== Match row — GRID with fixed center track (names can wrap freely) ===== */
 .match-card{
   display:grid;
-  grid-template-columns: minmax(0,1fr) var(--center-col) minmax(0,1fr);
+  grid-template-columns: 1fr var(--center-col-fixed) 1fr; /* center never shrinks */
   align-items:center;
-  gap:.55rem;
-  padding:.45rem .9rem;
-  min-height:50px;
+  column-gap: clamp(10px, 2vw, 18px);
+  padding:.50rem .9rem;
+  min-height:54px;                    /* grows with content automatically */
+  position:relative;
 }
 .match-card + .match-card{ border-top:1px solid rgba(255,255,255,.08); }
-.match-card:hover{ background: rgba(255,255,255,.03); }
+.match-card:hover{ background:rgba(255,255,255,.03); }
 
-/* Team blocks */
+/* Last row corners rounded to match the card */
+.match-card:last-child{
+  border-bottom-left-radius:inherit;
+  border-bottom-right-radius:inherit;
+}
+
+/* Left/right team lanes */
 .team-block{
   display:grid;
-  grid-template-columns: var(--crest-box) minmax(0,1fr);
+  grid-template-columns: var(--crest-box) minmax(0,1fr); /* text area can shrink/wrap */
   align-items:center;
   column-gap:8px;
-  min-width:0;
-  justify-items:start;
+  min-width:0;            /* allow shrinking instead of overflow */
+  overflow:visible;       /* do NOT clip text */
 }
 .team-block.right{
   grid-template-columns: minmax(0,1fr) var(--crest-box);
   justify-items:end;
 }
 
-/* Crest container */
+/* Center track */
+.match-details{
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  text-align:center;
+  white-space:nowrap;    /* keep time on one line */
+  overflow:visible;
+}
+
+/* Crest */
 .team-logo-wrap{
-  box-sizing:border-box;
-  width:var(--crest-box);
-  height:var(--crest-box);
+  box-sizing:border-box; width:var(--crest-box); height:var(--crest-box);
   border-radius:var(--crest-radius);
   background:rgba(255,255,255,.06);
   border:1px solid rgba(255,255,255,.12);
-  display:grid;
-  place-items:center;
-  overflow:hidden;
-  line-height:0;
+  display:grid; place-items:center; overflow:hidden; line-height:0;
   box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
 }
-
-/* Crest image */
 .match-card .team-logo{
-  display:block;
-  width:92% !important;
-  height:92% !important;
-  max-width:none !important;
-  max-height:none !important;
-  object-fit:contain;
-  object-position:center;
-  padding:0 !important;
+  display:block; width:92% !important; height:92% !important;
+  max-width:none !important; max-height:none !important;
+  object-fit:contain; object-position:center; padding:0 !important;
 }
 
-/* Team text */
+/* Team text — WRAP, never truncate */
 .team-info{
   display:flex; flex-direction:column; justify-content:center;
-  min-width:0; line-height:1.06;
+  min-width:0; line-height:1.12;
 }
 .team-info.right-info{ align-items:flex-end; text-align:right; }
-.team-name{ font-weight:700; font-size:.84rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; color:var(--text-100); }
+.team-name{
+  font-weight:700; font-size:.86rem; color:#e5e7eb;
+  white-space:normal !important;      /* allow wrapping */
+  overflow-wrap:anywhere !important;  /* break long compounds */
+  word-break:normal !important;
+  text-overflow:clip !important;      /* kill any ellipsis from elsewhere */
+}
 .team-place{ font-size:.62rem; color:#9ca3af; }
 
-/* Center column */
-.match-details{ display:flex; flex-direction:column; align-items:center; min-width: var(--center-col); }
+/* Time & status */
 .match-time{
-  color:#f9fafb; font-weight:800; font-variant-numeric: tabular-nums;
-  letter-spacing:.004em; line-height:1; font-size:.9rem;
+  color:#f9fafb; font-weight:800; font-variant-numeric:tabular-nums;
+  letter-spacing:.004em; line-height:1.05; font-size:.9rem;
 }
 .match-status{
-  margin-top:.12rem; font-size:.62rem; color:var(--text-200); padding:.1rem .36rem;
-  border-radius:6px; background: rgba(148,163,184,0.12); border: 1px solid rgba(255,255,255,0.12);
+  margin-top:.12rem; font-size:.62rem; color:var(--text-200);
+  padding:.1rem .36rem; border-radius:6px;
+  background:rgba(148,163,184,0.12); border:1px solid rgba(255,255,255,0.12);
 }
-.match-status.live{ color:#16a34a; background: rgba(22,163,74,0.12); border-color: rgba(22,163,74,0.35); }
+.match-status.live{ color:#16a34a; background:rgba(22,163,74,0.12); border-color:rgba(22,163,74,0.35); }
 
-/* ===== Right-rail search (clean, centered ✕ icon) ===== */
+/* ===== Right-rail search ===== */
 .qf-wrap{ position:relative; width:100%; }
-
 .qf-input{
-  box-sizing:border-box;
-  width:100%;
-  height:36px;                    /* stable control height */
-  padding:0 44px 0 12px;          /* room for the clear icon on the right */
-  border-radius:8px;
+  box-sizing:border-box; width:100%; height:36px;
+  padding:0 44px 0 12px; border-radius:8px;
   border:1px solid rgba(255,255,255,.12);
-  background: rgba(255,255,255,.06);
-  color:#fff;
-  font-size:.86rem;
-  line-height:36px;               /* crisp vertical centering */
-  outline:none;
+  background:rgba(255,255,255,.06); color:#fff;
+  font-size:.86rem; line-height:36px; outline:none;
 }
-.qf-input::placeholder{ color: rgba(255,255,255,.55); }
-.qf-input:focus{
-  border-color: rgba(255,255,255,.2);
-  background: rgba(255,255,255,.08);
-}
-
+.qf-input::placeholder{ color:rgba(255,255,255,.55); }
+.qf-input:focus{ border-color:rgba(255,255,255,.2); background:rgba(255,255,255,.08); }
 .qf-clear{
-  position:absolute;
-  right:10px;
-  top:50%;
-  transform:translateY(-50%);
-  width:24px;
-  height:24px;
-  display:grid;
-  place-items:center;
-  padding:0;
-  border:0;
-  border-radius:6px;
-  background:transparent;
-  color:#cbd5e1;
-  cursor:pointer;
+  position:absolute; right:10px; top:50%; transform:translateY(-50%);
+  width:24px; height:24px; display:grid; place-items:center;
+  padding:0; border:0; border-radius:6px; background:transparent; color:#cbd5e1; cursor:pointer;
 }
-.qf-clear svg{
-  width:12px;
-  height:12px;
-  stroke: currentColor;
-  stroke-width:2;
-  fill:none;
+.qf-clear svg{ width:12px; height:12px; stroke:currentColor; stroke-width:2; fill:none; }
+.qf-clear:hover{ background:rgba(255,255,255,.08); color:#fff; }
+.qf-clear:active{ transform:translateY(-50%) scale(.96); }
+
+/* ===== Responsive: shrink crests/fonts, keep full wrapping ===== */
+@media (max-width:1280px){
+  .team-place, .match-status{ display:none; }
 }
-.qf-clear:hover{
-  background: rgba(255,255,255,.08);
-  color:#fff;
+@media (max-width:1024px){
+  #today{ --crest-box:34px; }
+  .team-name{ font-size:.84rem; }
+  .match-card{ column-gap: clamp(8px, 1.6vw, 14px); padding:.44rem .8rem; }
 }
-.qf-clear:active{
-  transform: translateY(-50%) scale(.96);
+@media (max-width:700px){
+  #today{ --crest-box:30px; --center-col-fixed:10ch; }
+  .team-name{ font-size:.82rem; }
+}
+@media (max-width:480px){
+  #today{ --crest-box:28px; --center-col-fixed:10ch; }
+  .team-name{ font-size:.80rem; }
+  .match-time{ font-size:.86rem; }
 }

--- a/frontend/src/pages/homePage/styles/topBanner.css
+++ b/frontend/src/pages/homePage/styles/topBanner.css
@@ -1,3 +1,10 @@
+/* ─────────────────────────────────────────────────────────────
+   TopBanner — FULL UPDATED CSS (v3)
+   ─ ticker never overlaps next section
+   ─ small/medium: single column (text → cards), 3→2→1 grid
+   ─ large desktop: two columns; cards vertically centered in slab
+   ──────────────────────────────────────────────────────────── */
+
 :root{
   --ink-900:#070b11;
   --ink-800:#0b1118;
@@ -15,25 +22,24 @@
   --speed-med: 18s;
 }
 
-/* shell */
+/* ───────── Shell ───────── */
 .tb{
   position:relative;
   isolation:isolate;
   overflow:hidden;
-  /* keep this in sync with .tb-ticker height */
-  --ticker-h: 38px; /* NEW */
+  --ticker-h:38px;                       /* keep in sync with .tb-ticker */
   min-height:78vh;
+  padding-bottom:calc(var(--ticker-h) + 10px);  /* space for ticker */
   background:radial-gradient(1200px 750px at 50% 100%, var(--ink-800), var(--ink-900) 60%);
   border-bottom:1px solid var(--line);
-  opacity:0;
-  animation:f-in .4s ease-out forwards;
+  opacity:0; animation:f-in .4s ease-out forwards;
 }
 @keyframes f-in{
   from{opacity:0; transform:translateY(8px)}
   to{opacity:1; transform:translateY(0)}
 }
 
-/* bg */
+/* ───────── Background ───────── */
 .tb-bg{ position:absolute; inset:0; z-index:0; }
 .bg-mesh{
   position:absolute; inset:-15% -10% -10% -10%;
@@ -58,19 +64,53 @@
   background-size:220px 220px;
 }
 
-/* grid layout */
+/* ───────── Grid Layout ───────── */
 .tb-wrap{
   max-width:112rem; margin:0 auto;
   padding:5rem var(--pad) 4rem;
   padding-left:calc(var(--pad) + env(safe-area-inset-left));
-  display:grid; grid-template-columns:1fr 1fr; gap:3.6rem;
+  display:grid;
+  grid-template-columns:minmax(0,1fr) minmax(0,1fr);
+  grid-template-areas:"left right";
+  gap:3.6rem;
+  align-items:center;
   position:relative; z-index:1;
 }
-@media (max-width:1100px){
-  .tb-wrap{ grid-template-columns:1fr; gap:2rem; }
+.tb-left{ grid-area:left; position:relative; z-index:1; }
+.hero-right{ grid-area:right; position:relative; min-height:560px; }
+
+/* ───── Stacked mode (≤1280px): text then cards; hide decor ───── */
+@media (max-width:1280px){
+  .tb-wrap{
+    grid-template-columns:1fr;
+    grid-template-areas:
+      "left"
+      "right";
+    gap:1.8rem;
+    align-items:start;
+  }
+  .hero-right{ min-height:0; }
+  .hero-slab, .beam{ display:none !important; }
+
+  .panels{
+    position:relative !important;
+    top:auto !important; right:auto !important; left:auto !important;
+    transform:none !important;
+    width:100%;
+    max-width:980px;
+    margin:12px auto 18px;
+    display:grid; gap:12px;
+    grid-template-columns:repeat(3, minmax(0,1fr));
+  }
+}
+@media (max-width:900px){
+  .panels{ grid-template-columns:repeat(2, minmax(0,1fr)); }
+}
+@media (max-width:560px){
+  .panels{ grid-template-columns:1fr; }
 }
 
-/* left column */
+/* ───────── Typography & CTAs ───────── */
 .tb-title{ margin:0 0 .7rem 0; line-height:1.02; letter-spacing:-.02em; }
 .tb-strong{
   font-weight:900; font-size:clamp(3rem, 5.6vw, 4.9rem);
@@ -79,8 +119,7 @@
 }
 .tb-soft{ font-weight:800; font-size:clamp(3rem, 5.6vw, 4.9rem); color:var(--text-200); }
 .tb-sub{ margin:.9rem 0 1.25rem; color:var(--text-400); font-size:1.06rem; max-width:720px; }
-
-.tb-cta{ display:flex; gap:.85rem; flex-wrap:wrap; }
+.tb-cta{ display:flex; gap:.85rem; flex-wrap:wrap; margin-bottom:.4rem; }
 .cta-solid{
   display:inline-flex; align-items:center; justify-content:center; padding:.7rem 1.05rem;
   border-radius:12px; font-weight:800; color:#fff; text-decoration:none;
@@ -95,41 +134,56 @@
 }
 .cta-ghost:hover{ background:rgba(255,255,255,.06); border-color:rgba(255,255,255,.22); transform:translateY(-1px); }
 
-/* right column — diagonal slab + panels */
-.hero-right{ position:relative; min-height:520px; }
+/* ───────── Right Column (desktop ≥1281px) ───────── */
+@media (min-width:1281px){
+  .tb-wrap{
+    grid-template-columns:minmax(0,1fr) minmax(0,1fr);
+    grid-template-areas:"left right";
+    align-items:center;
+  }
+  .hero-right{ position:relative; min-height:560px; }
+  .hero-slab{ display:block; }
 
-/* keep the slab above the background but BELOW the ticker */
+  /* Vertically center the three cards inside the slab */
+  .panels{
+    position:absolute !important;
+    right:8%;
+    top:50%;
+    transform:translateY(-50%);
+    z-index:1;
+    width:min(460px, 44vw);
+    margin:0;                       /* no layout margins when absolute */
+    display:grid; gap:14px;
+    grid-template-columns:1fr;      /* stack three cards */
+  }
+}
+
+/* diagonal glass slab (desktop only; hidden in stacked mode) */
 .hero-slab{
-  /* OLD: inset:-8% -6% -10% 20%; */
-  inset: -8% -6% calc(var(--ticker-h) + 6px) 20%;  /* NEW: crop above ticker */
   position:absolute;
+  inset: -8% -6% calc(var(--ticker-h) + 6px) 20%;  /* crop above ticker */
   background:
     linear-gradient(160deg, rgba(255,255,255,.06), rgba(255,255,255,0) 55%),
     radial-gradient(60% 80% at 85% 30%, rgba(96,165,250,.22), rgba(167,139,250,.16) 60%, transparent 75%);
   backdrop-filter: blur(8px);
   border:1px solid rgba(255,255,255,.08);
-  clip-path: polygon(18% 0, 100% 0, 100% 100%, 0 100%); /* diagonal left edge */
+  clip-path: polygon(18% 0, 100% 0, 100% 100%, 0 100%);
   border-radius:22px; opacity:.9;
-  z-index:0;                 /* NEW: ensure under ticker */
-  pointer-events:none;       /* optional: make it non-interactive */
+  z-index:0; pointer-events:none;
 }
 
-/* slow beams */
+/* slow beams (desktop only; hidden in stacked mode) */
 .beam{
   position:absolute; left:24%; right:6%; height:2px;
   background:linear-gradient(90deg, rgba(255,255,255,0), rgba(255,255,255,.35), rgba(255,255,255,0));
-  filter:blur(.6px); opacity:.5;
+  filter:blur(.6px); opacity:.5; z-index:0;
 }
 .beam.b1{ top:26%; animation:slide1 9s linear infinite; }
 .beam.b2{ top:62%; animation:slide2 11s linear infinite; }
 @keyframes slide1{ 0%{transform:translateX(0)} 100%{transform:translateX(-18%)} }
 @keyframes slide2{ 0%{transform:translateX(-10%)} 100%{transform:translateX(10%)} }
 
-/* stats panels */
-.panels{
-  position:absolute; right:8%; top:14%;
-  display:grid; gap:14px; width:min(440px, 46vw);
-}
+/* stat panels */
 .panel{
   display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:12px;
   padding:14px 16px; border-radius:16px;
@@ -145,13 +199,13 @@
 .pn{ font-weight:900; color:#eaf2ff; font-size:1.1rem; }
 .pd{ grid-column:2 / -1; margin-top:-2px; color:#9fb0c8; font-size:.82rem; }
 
-/* ticker — raise above slab */
+/* ───────── Ticker ───────── */
 .tb-ticker{
   position:absolute; left:0; right:0; bottom:0; height:38px;
   overflow:hidden;
   border-top:1px solid rgba(255,255,255,.06);
   background:linear-gradient(180deg, rgba(12,16,24,.6), rgba(12,16,24,.85));
-  z-index:5; /* NEW: sits above .hero-slab/.tb-wrap */
+  z-index:5;
 }
 .track{
   display:flex; gap:18px; align-items:center; white-space:nowrap;
@@ -166,7 +220,7 @@
 .t-league{ opacity:.6; font-weight:800; font-size:.78rem; }
 
 .fade{
-  position:absolute; top:0; bottom:0; width:120px; pointer-events:none; z-index:2;
+  position:absolute; top:0; bottom:0; width:120px; pointer-events:none; z-index:6;
   background:linear-gradient(90deg, rgba(12,16,24,.9), rgba(12,16,24,0));
 }
 .fade.r{ right:0; transform:scaleX(-1); }

--- a/frontend/src/pages/newsPage/NewsPage.jsx
+++ b/frontend/src/pages/newsPage/NewsPage.jsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import "../../App.css";
+import "./styles/newsPage.css";
+  // reuse the News styles
+import { FaNewspaper } from "react-icons/fa";
+import { useSearchParams } from "react-router-dom";
+import NavBar from "../homePage/NavBar";
+import Footer from "../homePage/Footer";
+
+// ───────────────────────────────────────────────
+// Constants & helpers
+// ───────────────────────────────────────────────
+const TABS = [
+  { key: "all", label: "All" },
+  { key: "transfers", label: "Transfers" },
+  { key: "injuries", label: "Injuries" },
+  { key: "matchreports", label: "Match reports" },
+];
+
+const API = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/+$/, "");
+
+function timeAgo(isoUtc) {
+  try {
+    const d = new Date(isoUtc);
+    const s = Math.max(0, (Date.now() - d.getTime()) / 1000);
+    if (s < 60) return "just now";
+    const m = s / 60, h = m / 60, d2 = h / 24;
+    if (m < 60) return `${Math.floor(m)}m ago`;
+    if (h < 24) return `${Math.floor(h)}h ago`;
+    return `${Math.floor(d2)}d ago`;
+  } catch {
+    return "";
+  }
+}
+
+function stripTags(html = "") {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  return (tmp.textContent || tmp.innerText || "").trim();
+}
+
+// ───────────────────────────────────────────────
+// Page component (full News experience)
+// ───────────────────────────────────────────────
+export default function NewsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialTab = (() => {
+    const t = (searchParams.get("tab") || "all").toLowerCase();
+    return TABS.some(x => x.key === t) ? t : "all";
+  })();
+
+  const [tab, setTab] = useState(initialTab);
+  const [items, setItems] = useState([]);
+  const [nextCursor, setNextCursor] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [initialLoaded, setInitialLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const abortRef = useRef(null);
+
+  // Keep URL in sync with current tab
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams);
+    if (tab === "all") params.delete("tab");
+    else params.set("tab", tab);
+    setSearchParams(params, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab]);
+
+  const ids = useMemo(() => new Set(items.map(i => i.article_id)), [items]);
+
+  async function fetchPage({ reset = false } = {}) {
+    if (abortRef.current) abortRef.current.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setLoading(true);
+    setError("");
+    try {
+      const qs = new URLSearchParams();
+      qs.set("limit", "20");
+      if (tab !== "all") qs.set("tab", tab);
+      if (!reset && nextCursor) qs.set("cursor", nextCursor);
+
+      const res = await fetch(`${API}/news?${qs.toString()}`, { signal: ac.signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+
+      const fresh = (data.items || []).filter(it => !ids.has(it.article_id));
+      setItems(prev => (reset ? fresh : prev.concat(fresh)));
+      setNextCursor(data.next_cursor || null);
+      setInitialLoaded(true);
+    } catch (e) {
+      if (e.name !== "AbortError") setError("Failed to load news.");
+    } finally {
+      if (abortRef.current === ac) abortRef.current = null;
+      setLoading(false);
+    }
+  }
+
+  // Initial load + when tab changes
+  useEffect(() => {
+    setItems([]);
+    setNextCursor(null);
+    setInitialLoaded(false);
+    fetchPage({ reset: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab]);
+
+  return (
+    <div className="app">
+      <NavBar />
+
+      <main className="main-content">
+        <section id="news" className="section-block">
+          <div className="section-header">
+            <div className="section-icon-box news-icon-box">
+              <FaNewspaper className="section-icon news-icon" />
+            </div>
+            <h2 className="section-title">News</h2>
+          </div>
+
+          {/* Tabs */}
+          <div className="news-tabs" role="tablist" aria-label="News tabs">
+            {TABS.map(t => (
+              <button
+                key={t.key}
+                role="tab"
+                aria-selected={tab === t.key}
+                className={`news-tab ${tab === t.key ? "is-active" : ""}`}
+                onClick={() => setTab(t.key)}
+                disabled={loading && tab === t.key}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          {/* States */}
+          {error && <p className="muted">{error}</p>}
+          {!initialLoaded && loading && <p className="muted">Loading news…</p>}
+          {initialLoaded && items.length === 0 && !loading && (
+            <p className="muted">No news yet.</p>
+          )}
+
+          {/* Grid */}
+          <div className="news-grid">
+            {items.map(it => (
+              <article key={it.article_id} className="news-card tile">
+                {it.image_url ? (
+                  <a
+                    href={it.url}
+                    className="news-thumb"
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label={it.title}
+                  >
+                    <img src={it.image_url} alt="" loading="lazy" />
+                  </a>
+                ) : (
+                  <div className="news-thumb news-thumb--empty" />
+                )}
+
+                <div className="news-body">
+                  <h3 className="news-title">
+                    <a href={it.url} target="_blank" rel="noreferrer">
+                      {it.title}
+                    </a>
+                  </h3>
+
+                  <div className="news-meta">
+                    <span className="news-source">{it.source || "Source"}</span>
+                    <span className="news-dot">•</span>
+                    <time dateTime={it.published_at_utc}>{timeAgo(it.published_at_utc)}</time>
+                    {it.tab && (
+                      <>
+                        <span className="news-dot">•</span>
+                        <span className="news-tabchip">{it.tab}</span>
+                      </>
+                    )}
+                  </div>
+
+                  {it.summary && (
+                    <p className="news-summary clamp-3">{stripTags(it.summary)}</p>
+                  )}
+
+                  <div className="news-footer">
+                    <a className="news-read" href={it.url} target="_blank" rel="noreferrer">
+                      Read article →
+                    </a>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          {/* Load more */}
+          {nextCursor && (
+            <div className="load-more-wrap">
+              <button
+                className="load-more-btn"
+                onClick={() => fetchPage()}
+                disabled={loading}
+              >
+                {loading ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          )}
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/pages/newsPage/styles/newsPage.css
+++ b/frontend/src/pages/newsPage/styles/newsPage.css
@@ -1,0 +1,105 @@
+/* ===== News Section ===== */
+#news{
+  --grid-gap: 20px;
+  --card-radius: 14px;
+  --thumb-ratio: 56.25%; /* 16:9 */
+}
+
+/* Tabs */
+.news-tabs{
+  display:flex; gap:.5rem; margin:.4rem 0 1rem 0; flex-wrap:wrap;
+}
+.news-tab{
+  background:#1d2432; color:#d1d5db; font-size:.82rem; font-weight:700;
+  padding:.35rem .7rem; border:1px solid rgba(209,213,219,.18);
+  border-radius:10px; cursor:pointer; transition:all .18s ease;
+}
+.news-tab:hover{ background:#232a3a; border-color:rgba(209,213,219,.35); color:#f3f4f6; }
+.news-tab.is-active{
+  background:rgba(59,130,246,.16);
+  border-color:rgba(59,130,246,.38);
+  color:#e8f0ff;
+}
+
+/* Grid */
+.news-grid{
+  display:grid;
+  grid-template-columns: repeat(3, minmax(0,1fr));
+  gap: var(--grid-gap);
+}
+@media (max-width: 1200px){
+  .news-grid{ grid-template-columns: repeat(2, minmax(0,1fr)); }
+}
+@media (max-width: 700px){
+  .news-grid{ grid-template-columns: 1fr; }
+}
+
+/* Card */
+.news-card{
+  display:flex; flex-direction:column;
+  border-radius: var(--card-radius);
+  overflow:hidden;
+}
+.news-thumb{
+  display:block; position:relative; width:100%;
+  padding-top: var(--thumb-ratio); /* aspect ratio */
+  background:rgba(255,255,255,.04);
+  border-bottom:1px solid rgba(255,255,255,.08);
+}
+.news-thumb img{
+  position:absolute; inset:0; width:100%; height:100%;
+  object-fit:cover; display:block;
+}
+.news-thumb--empty{
+  display:block; height:0; padding-top: var(--thumb-ratio);
+  background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+}
+
+/* Body */
+.news-body{ padding:.8rem .9rem 1rem; display:flex; flex-direction:column; gap:.4rem; }
+.news-title{
+  margin:0; font-size:1.02rem; line-height:1.22; font-weight:800; color:#fff;
+}
+.news-title a{ color:inherit; text-decoration:none; }
+.news-title a:hover{ text-decoration:underline; }
+
+.news-meta{
+  display:flex; align-items:center; gap:.4rem;
+  font-size:.78rem; color:#aeb7c4;
+}
+.news-source{ font-weight:700; }
+.news-dot{ opacity:.6; }
+.news-tabchip{
+  text-transform:capitalize;
+  background:rgba(255,255,255,.06);
+  border:1px solid rgba(255,255,255,.12);
+  padding:.08rem .38rem; border-radius:999px; font-size:.72rem;
+}
+
+.news-summary{
+  color:#cfd6e2; font-size:.9rem; line-height:1.35;
+}
+
+/* Clamp helper (WebKit/Chromium) */
+.clamp-3{
+  display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical;
+  overflow:hidden;
+}
+
+/* Footer */
+.news-footer{ margin-top:.2rem; }
+.news-read{
+  display:inline-block; font-size:.85rem; font-weight:700; color:#d1e0ff;
+  text-decoration:none; border-bottom:1px solid rgba(209,224,255,.35);
+}
+.news-read:hover{ color:#fff; border-color:#fff; }
+
+/* Load more */
+.load-more-wrap{ display:flex; margin-top:1rem; }
+.load-more-btn{
+  background:#1d2432; color:#d1d5db; font-size:.86rem; font-weight:800;
+  padding:.5rem .9rem; border:1px solid rgba(209,213,219,.18);
+  border-radius:10px; cursor:pointer; transition:all .18s ease;
+}
+.load-more-btn:hover{ background:#232a3a; border-color:rgba(209,213,219,.40); color:#f3f4f6; }
+.load-more-btn:disabled{ opacity:.6; cursor:default; }


### PR DESCRIPTION
What’s in this PR
- Frontend: adds a News section on the homepage.
- Backend: adds /news endpoint (tabs: match reports, transfers, injuries).
- CI: frontend-ci and backend-ci now run only on pull requests (no post-merge reruns).
