### PR TITLE
Add country filter endpoints, integration tests, and CI DB setup

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,15 +1,47 @@
 name: backend-ci  # CI for the FastAPI backend
 
 on:
-  # Run CI on PRs that modify backend/ or this workflow file
+  # Run CI on PRs that modify backend/, etl/ (tests import from there), or this workflow file
   pull_request:
     paths:
       - 'backend/**'
+      - 'etl/**'
       - '.github/workflows/backend-ci.yml'
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
+
+    # ─────────────────────────────────────
+    # Test DB environment variables (used by DB_TEST_CREDENTIALS)
+    # ─────────────────────────────────────
+    env:
+      # In GitHub Actions, the Postgres service is reachable from the runner at localhost:5432
+      DB_HOST: localhost
+      DB_PORT: 5432
+
+      # These should be set as GitHub Secrets (recommended)
+      DB_TEST_NAME: ${{ secrets.DB_TEST_NAME }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+
+    # ─────────────────────────────────────
+    # Temporary Postgres DB for integration tests
+    # ─────────────────────────────────────
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: ${{ secrets.DB_TEST_NAME }}
+          POSTGRES_USER: ${{ secrets.DB_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres -d postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
 
     # All shell steps below execute inside backend/
     defaults:
@@ -32,6 +64,22 @@ jobs:
       # 3) Install backend dependencies from YOUR exact file name
       - name: Install dependencies
         run: pip install -r requirements_api.txt
+
+      # 3.5) Install psql client so we can apply schema SQL
+      - name: Install Postgres client (psql)
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      # 3.6) Create the test schema in the fresh CI Postgres
+      - name: Create test schema
+        env:
+          PGPASSWORD: ${{ env.DB_PASSWORD }}
+        run: |
+          psql \
+            -h $DB_HOST \
+            -p $DB_PORT \
+            -U $DB_USER \
+            -d $DB_TEST_NAME \
+            -f tests/schema_test.sql
 
       # 4) Run tests only if a tests/ folder exists (auto-skip otherwise)
       - name: Run tests (if present)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,9 @@ from .routers import teamPage
 from .routers import matchDetailsPage
 from .routers import leagueModal
 from .routers import news
+from .routers import leagues_by_country
+
+
 
 
 
@@ -99,4 +102,6 @@ app.include_router(teamPage.router)
 app.include_router(matchDetailsPage.router)
 app.include_router(leagueModal.router)
 app.include_router(news.router)
+app.include_router(leagues_by_country.router)
+
 

--- a/backend/app/routers/leagues_by_country.py
+++ b/backend/app/routers/leagues_by_country.py
@@ -1,0 +1,150 @@
+"""
+Routes for browsing leagues by country
+──────────────────────────────────────
+Endpoints
+• GET /countries                  – list of distinct countries that have leagues
+• GET /leagues_by_country         – leagues for a given country name
+"""
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_session
+
+logger = logging.getLogger(__name__)
+
+# This router will be mounted in main.py, e.g.:
+#   app.include_router(router)
+router = APIRouter(tags=["leagues_by_country"])
+
+
+# ────────────────────────────────────────────────
+# Pydantic models ⇢ shape of outgoing JSON
+# ────────────────────────────────────────────────
+class CountryOut(BaseModel):
+    """Single country that has at least one league in the `leagues` table."""
+    country: str
+
+
+class LeagueByCountryOut(BaseModel):
+    """
+    A league that belongs to a specific country.
+
+    `id` is used internally by the frontend (navigation, React keys, etc.),
+    but does not need to be *displayed* to the user.
+    """
+    id: int
+    name: str
+    country: str
+    logo_url: str
+
+
+# ────────────────────────────────────────────────
+# Routes
+# ────────────────────────────────────────────────
+@router.get("/countries", response_model=List[CountryOut])
+async def list_countries(db: AsyncSession = Depends(get_session)):
+    """
+    Return the list of distinct countries that have at least one league.
+
+    Source of truth is `leagues.league_country`.
+    Example response:
+        [
+          { "country": "Brazil" },
+          { "country": "England" },
+          { "country": "Mexico" },
+          { "country": "Spain" }
+        ]
+    """
+    sql = text(
+        """
+        SELECT DISTINCT
+               league_country AS country
+        FROM   leagues
+        WHERE  league_country IS NOT NULL
+        ORDER  BY league_country;
+        """
+    )
+
+    try:
+        rows = (await db.execute(sql)).mappings()
+        # rows is an iterable of dict-like objects; Pydantic will handle them.
+        return list(rows)
+    except SQLAlchemyError as err:
+        logger.exception("DB error while fetching countries")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error",
+        ) from err
+
+
+@router.get("/leagues_by_country", response_model=List[LeagueByCountryOut])
+async def leagues_by_country(
+    country: str = Query(..., description="Exact league_country value, e.g. 'Spain'"),
+    db: AsyncSession = Depends(get_session),
+):
+    """
+    Return all leagues for a given country.
+
+    • `country` maps directly to `leagues.league_country`
+      (e.g. 'Spain', 'Mexico', 'England').
+
+    Behavior:
+    • If the country exists but has no leagues → empty list, 200 OK.
+    • If caller passes a typo / unknown country → also an empty list.
+      (This keeps the API simple for the frontend.)
+
+    Example response:
+        [
+          {
+            "id": 143,
+            "name": "Copa del Rey",
+            "country": "Spain",
+            "logo_url": "https://media.api-sports.io/football/leagues/143.png"
+          },
+          {
+            "id": 140,
+            "name": "La Liga",
+            "country": "Spain",
+            "logo_url": "https://media.api-sports.io/football/leagues/140.png"
+          }
+        ]
+    """
+    # Normalize basic whitespace so " Spain " still works.
+    country = country.strip()
+
+    if not country:
+        # Guard against empty query param like ?country= or just spaces
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Query parameter 'country' must be a non-empty string.",
+        )
+
+    sql = text(
+        """
+        SELECT  league_id       AS id,
+                league_name     AS name,
+                league_country  AS country,
+                league_logo_url AS logo_url
+        FROM    leagues
+        WHERE   league_country = :country
+        ORDER BY league_name;
+        """
+    )
+
+    try:
+        rows = (await db.execute(sql, {"country": country})).mappings()
+        # If no leagues match, this will just be an empty list → 200 OK.
+        return list(rows)
+    except SQLAlchemyError as err:
+        logger.exception("DB error while fetching leagues for country=%s", country)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error",
+        ) from err

--- a/backend/requirements_api.txt
+++ b/backend/requirements_api.txt
@@ -35,3 +35,7 @@ uvicorn==0.34.2
 uvloop==0.21.0
 watchfiles==1.0.5
 websockets==15.0.1
+pytest
+pytest-anyio
+httpx
+

--- a/backend/tests/schema_test.sql
+++ b/backend/tests/schema_test.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS leagues (
+    league_id INTEGER PRIMARY KEY,
+    league_name TEXT NOT NULL,
+    league_logo_url TEXT,
+    league_country TEXT
+);

--- a/backend/tests/test_country_league_endpoints.py
+++ b/backend/tests/test_country_league_endpoints.py
@@ -31,8 +31,8 @@ sys.path.append(str(BASE_DIR / "backend"))
 # Project imports
 # ─────────────────────────────────────
 
-from get_db_conn import get_db_connection  # psycopg2 helper (main/test DB)
-from credentials import DB_TEST_CREDENTIALS
+from get_db_conn import get_db_connection, DB_TEST_CREDENTIALS
+
 
 # Import the actual route functions we want to test
 from app.routers.leagues_by_country import (

--- a/backend/tests/test_country_league_endpoints.py
+++ b/backend/tests/test_country_league_endpoints.py
@@ -1,0 +1,244 @@
+import os
+import sys
+from typing import List
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+# ─────────────────────────────────────
+# Compute repo root and adjust sys.path
+# ─────────────────────────────────────
+
+# Current file:  <repo_root>/backend/tests/test_country_league_endpoints.py
+# parents[0] = tests
+# parents[1] = backend
+# parents[2] = repo root
+BASE_DIR = Path(__file__).resolve().parents[2]  # repo root
+
+# Add <repo_root>/etl/test_scripts so we can import get_db_conn.py
+sys.path.append(str(BASE_DIR / "etl" / "test_scripts"))
+
+# Add <repo_root>/etl/config so we can import credentials.py
+sys.path.append(str(BASE_DIR / "etl" / "config"))
+
+# Add <repo_root>/backend so we can import app code
+sys.path.append(str(BASE_DIR / "backend"))
+
+# ─────────────────────────────────────
+# Project imports
+# ─────────────────────────────────────
+
+from get_db_conn import get_db_connection  # psycopg2 helper (main/test DB)
+from credentials import DB_TEST_CREDENTIALS
+
+# Import the actual route functions we want to test
+from app.routers.leagues_by_country import (
+    list_countries as list_countries_endpoint,
+    leagues_by_country as leagues_by_country_endpoint,
+)
+
+# Build async SQLAlchemy URL for the TEST DB
+ASYNC_TEST_DB_URL = (
+    f"postgresql+asyncpg://"
+    f"{DB_TEST_CREDENTIALS['user']}:"
+    f"{DB_TEST_CREDENTIALS['password']}@"
+    f"{DB_TEST_CREDENTIALS['host']}:"
+    f"{DB_TEST_CREDENTIALS['port']}/"
+    f"{DB_TEST_CREDENTIALS['dbname']}"
+)
+
+# ─────────────────────────────────────
+# Test DB seeding helpers (sync, psycopg2)
+# ─────────────────────────────────────
+
+def seed_leagues_in_test_db(include_null_country: bool = False):
+    """
+    Seed the TEST database's `leagues` table with a small, known data set.
+
+    NOTE:
+    - This function assumes the `leagues` table already exists.
+    - In CI, schema is created via backend/tests/schema_test.sql (run before pytest).
+    """
+    conn = get_db_connection("test")
+    cur = conn.cursor()
+
+    cur.execute("DELETE FROM leagues;")
+
+    insert_sql = """
+        INSERT INTO leagues (league_id, league_name, league_logo_url, league_country)
+        VALUES (%s, %s, %s, %s);
+    """
+
+    rows = [
+        (1, "Premier League", "https://example.com/epl.png", "England"),
+        (2, "Championship", "https://example.com/championship.png", "England"),
+        (3, "La Liga", "https://example.com/laliga.png", "Spain"),
+        (4, "Serie A", "https://example.com/seriea.png", "Italy"),
+    ]
+
+    if include_null_country:
+        rows.append((5, "Null Country League", "https://example.com/null.png", None))
+
+    cur.executemany(insert_sql, rows)
+    conn.commit()
+
+    cur.close()
+    conn.close()
+
+
+def clear_leagues_in_test_db():
+    """
+    Clear the TEST database's `leagues` table.
+
+    NOTE:
+    - This function assumes the `leagues` table already exists.
+    - In CI, schema is created via backend/tests/schema_test.sql (run before pytest).
+    """
+    conn = get_db_connection("test")
+    cur = conn.cursor()
+    cur.execute("DELETE FROM leagues;")
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+# ─────────────────────────────────────
+# AnyIO backend fixture
+# ─────────────────────────────────────
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─────────────────────────────────────
+# Tests
+# ─────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_countries_returns_distinct_sorted():
+    """
+    /countries:
+      - returns distinct countries
+      - sorted alphabetically
+      - ignores NULL countries
+    """
+    seed_leagues_in_test_db(include_null_country=True)
+
+    async_engine = create_async_engine(ASYNC_TEST_DB_URL, echo=False, future=True)
+    AsyncSessionLocal = sessionmaker(
+        async_engine,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )
+
+    async with AsyncSessionLocal() as session:
+        result = await list_countries_endpoint(db=session)
+        data = [dict(row) for row in result]
+
+        # Your SQL orders by league_country, so expect alphabetical order:
+        # England, Italy, Spain
+        assert data == [
+            {"country": "England"},
+            {"country": "Italy"},
+            {"country": "Spain"},
+        ]
+
+    await async_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_leagues_by_country_happy_path():
+    """
+    /leagues_by_country:
+      - filters by exact country
+      - orders by league_name ascending
+    """
+    seed_leagues_in_test_db()
+
+    async_engine = create_async_engine(ASYNC_TEST_DB_URL, echo=False, future=True)
+    AsyncSessionLocal = sessionmaker(
+        async_engine,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )
+
+    async with AsyncSessionLocal() as session:
+        england_result = await leagues_by_country_endpoint(country="England", db=session)
+        england_data = [dict(row) for row in england_result]
+
+        assert len(england_data) == 2
+        assert [row["name"] for row in england_data] == ["Championship", "Premier League"]
+        assert {row["country"] for row in england_data} == {"England"}
+
+        italy_result = await leagues_by_country_endpoint(country="Italy", db=session)
+        italy_data = [dict(row) for row in italy_result]
+        assert len(italy_data) == 1
+        assert italy_data[0]["name"] == "Serie A"
+        assert italy_data[0]["country"] == "Italy"
+
+        spain_result = await leagues_by_country_endpoint(country="Spain", db=session)
+        spain_data = [dict(row) for row in spain_result]
+        assert len(spain_data) == 1
+        assert spain_data[0]["name"] == "La Liga"
+        assert spain_data[0]["country"] == "Spain"
+
+        # whitespace normalization check (your endpoint does .strip())
+        spain_ws_result = await leagues_by_country_endpoint(country="  Spain  ", db=session)
+        spain_ws_data = [dict(row) for row in spain_ws_result]
+        assert len(spain_ws_data) == 1
+        assert spain_ws_data[0]["name"] == "La Liga"
+
+    await async_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_leagues_by_country_empty_table_and_unknown_country():
+    """
+    /leagues_by_country edge cases:
+      - empty table -> []
+      - unknown country -> []
+    """
+    clear_leagues_in_test_db()
+
+    async_engine = create_async_engine(ASYNC_TEST_DB_URL, echo=False, future=True)
+    AsyncSessionLocal = sessionmaker(
+        async_engine,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )
+
+    async with AsyncSessionLocal() as session:
+        result_empty = await leagues_by_country_endpoint(country="England", db=session)
+        assert [dict(row) for row in result_empty] == []
+
+        result_unknown = await leagues_by_country_endpoint(country="NowhereLand", db=session)
+        assert [dict(row) for row in result_unknown] == []
+
+    await async_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_leagues_by_country_rejects_blank_country():
+    """
+    Your endpoint should 400 on blank/whitespace country values.
+    """
+    seed_leagues_in_test_db()
+
+    async_engine = create_async_engine(ASYNC_TEST_DB_URL, echo=False, future=True)
+    AsyncSessionLocal = sessionmaker(
+        async_engine,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )
+
+    async with AsyncSessionLocal() as session:
+        with pytest.raises(HTTPException) as exc:
+            await leagues_by_country_endpoint(country="   ", db=session)
+
+        assert exc.value.status_code == 400
+
+    await async_engine.dispose()

--- a/backend/tests/test_country_league_http.py
+++ b/backend/tests/test_country_league_http.py
@@ -1,0 +1,72 @@
+import pytest
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Reuse the seeding + test DB URL you already maintain in one place.
+# This also avoids duplicating that same rows[] list.
+from test_country_league_endpoints import seed_leagues_in_test_db, ASYNC_TEST_DB_URL
+
+from app.main import app
+from app.db import get_session
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def client():
+    """
+    HTTP client that hits the real FastAPI app (ASGI),
+    while overriding get_session to use the TEST database.
+    """
+    async_engine = create_async_engine(ASYNC_TEST_DB_URL, echo=False, future=True)
+    AsyncSessionLocal = sessionmaker(
+        async_engine,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )
+
+    async def override_get_session():
+        async with AsyncSessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+    await async_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_http_countries_and_leagues_by_country(client):
+    seed_leagues_in_test_db()
+
+    # /countries
+    r = await client.get("/countries")
+    assert r.status_code == 200
+    countries = r.json()
+    assert isinstance(countries, list)
+    assert all("country" in x for x in countries)
+
+    country_names = [x["country"] for x in countries]
+    assert "England" in country_names
+    assert "Spain" in country_names
+    assert "Italy" in country_names
+
+    # /leagues_by_country?country=England
+    r2 = await client.get("/leagues_by_country", params={"country": "England"})
+    assert r2.status_code == 200
+    leagues = r2.json()
+    assert isinstance(leagues, list)
+    assert len(leagues) == 2
+
+    # ordering + shape
+    assert [x["name"] for x in leagues] == ["Championship", "Premier League"]
+    assert {x["country"] for x in leagues} == {"England"}
+    assert all("logo_url" in x for x in leagues)

--- a/etl/src/tables/prod_tables/create_leagues_table.py
+++ b/etl/src/tables/prod_tables/create_leagues_table.py
@@ -2,22 +2,37 @@ import os
 import sys
 
 # Add the `test_scripts` directory to sys.path for imports
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../test_scripts")))
+# (Adjust the relative path if your structure is slightly different.)
+sys.path.append(
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../../../test_scripts")
+    )
+)
 
 from get_db_conn import get_db_connection
 
-def create_leagues_table():
+
+def create_leagues_table(target_db: str = "main"):
     """
-    Creates the `leagues` table in the database if it doesn't already exist,
+    Creates the `leagues` table in the selected database if it doesn't already exist,
     matching the schema from your ERD:
-    
-    Leagues {
-        league_id int pk
-        league_name varchar
-        league_logo_url text
-        league_country varchar
-    }
+
+        Leagues {
+            league_id       int pk
+            league_name     varchar
+            league_logo_url text
+            league_country  varchar
+        }
+
+    Args:
+        target_db (str, optional):
+            Which DB to create the table in:
+            - "main" (default): your main app DB
+            - "test": your test DB (e.g. footysphere_test_db)
     """
+    # Normalize the DB selector
+    target_db = (target_db or "main").lower()
+
     create_table_query = """
     CREATE TABLE IF NOT EXISTS leagues (
         league_id INT PRIMARY KEY,
@@ -28,20 +43,39 @@ def create_leagues_table():
     """
 
     try:
-        conn = get_db_connection()
+        # 🔹 This now uses the same helper you just updated:
+        #    get_db_connection("main") or get_db_connection("test")
+        conn = get_db_connection(target_db)
         cur = conn.cursor()
 
         # Execute the table creation query
         cur.execute(create_table_query)
         conn.commit()
 
-        print("Table `leagues` created successfully.")
+        print(f"Table `leagues` created successfully in {target_db.upper()} DB.")
 
         cur.close()
         conn.close()
     except Exception as e:
-        print("Error creating the `leagues` table:", e)
+        print(f"Error creating the `leagues` table in {target_db.upper()} DB:", e)
+
 
 if __name__ == "__main__":
-    print("Creating the `leagues` table...")
-    create_leagues_table()
+    """
+    Run this script to create the `leagues` table in MAIN or TEST DB.
+
+    Examples (from your repo root):
+
+        python path/to/create_leagues_table.py
+            -> creates table in MAIN DB (default)
+
+        python path/to/create_leagues_table.py main
+            -> explicitly creates table in MAIN DB
+
+        python path/to/create_leagues_table.py test
+            -> creates table in TEST DB
+    """
+    # Decide which DB to target from CLI arg; default to "main"
+    arg = sys.argv[1].lower() if len(sys.argv) > 1 else "main"
+    print(f"Creating `leagues` table in {arg.upper()} DB...")
+    create_leagues_table(arg)

--- a/etl/test_scripts/get_db_conn.py
+++ b/etl/test_scripts/get_db_conn.py
@@ -2,47 +2,124 @@ import os
 import sys
 import psycopg2
 
-# Add the `config` directory to sys.path for credentials import
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../config")))
+# Ensure we can import from the config directory (where credentials.py lives)
+# Adjust the relative path if your structure is slightly different.
+sys.path.append(
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../config")
+    )
+)
 
-from credentials import DB_CREDENTIALS
+from credentials import DB_CREDENTIALS, DB_TEST_CREDENTIALS
 
-def get_db_connection():
+
+def get_db_connection(target_db: str = "main"):
     """
-    Creates and returns a connection to the PostgreSQL database.
-    Reads credentials from the DB_CREDENTIALS dictionary in credentials.py.
+    Create and return a connection to the PostgreSQL database.
+
+    This is the ONE helper your other scripts should import and use.
+
+    Args:
+        target_db (str, optional):
+            Which database to connect to:
+            - "main" (default): uses DB_CREDENTIALS (your main app DB)
+            - "test": uses DB_TEST_CREDENTIALS (your test DB, e.g. footysphere_test_db)
 
     Returns:
-        psycopg2.extensions.connection: A live connection object to the database.
+        psycopg2.extensions.connection:
+            A live connection object to the selected database.
 
     Raises:
-        Exception: If the connection fails, an error message is printed and re-raised.
+        Exception:
+            If the connection fails, prints an error and re-raises.
     """
+    # Normalize the input (handle None / weird casing)
+    target_db = (target_db or "main").lower()
+
+    if target_db == "main":
+        creds = DB_CREDENTIALS
+    elif target_db == "test":
+        creds = DB_TEST_CREDENTIALS
+    else:
+        raise ValueError(
+            f"Unknown target_db value: {target_db!r}. Use 'main' or 'test'."
+        )
+
     try:
         conn = psycopg2.connect(
-            host=DB_CREDENTIALS["host"],
-            port=DB_CREDENTIALS["port"],
-            database=DB_CREDENTIALS["dbname"],
-            user=DB_CREDENTIALS["user"],
-            password=DB_CREDENTIALS["password"]
+            host=creds["host"],
+            port=creds["port"],
+            database=creds["dbname"],
+            user=creds["user"],
+            password=creds["password"],
         )
         return conn
     except Exception as e:
-        print("Error connecting to the database:", e)
+        print(f"Error connecting to the {target_db.upper()} database:", e)
         raise
 
-def test_db_connection():
+
+def smoke_test_connection(target_db: str = "main", list_tables: bool = True):
     """
-    Tests the database connection using the reusable connection logic.
-    Prints a success message if the connection works, or an error message if it fails.
+    Manual smoke test for the DB connection.
+
+    You can run this file directly to check MAIN or TEST DB.
+
+    Args:
+        target_db (str, optional):
+            "main" or "test" (defaults to "main").
+        list_tables (bool, optional):
+            If True, will also list tables from the 'public' schema.
     """
+    target_db = (target_db or "main").lower()
+
     try:
-        conn = get_db_connection()
-        print("Modular test: Connection successful!")
+        conn = get_db_connection(target_db)
+        cur = conn.cursor()
+
+        # Basic 'SELECT 1' sanity check
+        cur.execute("SELECT 1;")
+        cur.fetchone()
+
+        print(f"\n{target_db.upper()} DB connection successful!")
+
+        if list_tables:
+            print("Listing tables in 'public' schema:")
+            cur.execute(
+                "SELECT tablename FROM pg_tables WHERE schemaname = 'public';"
+            )
+            rows = cur.fetchall()
+            if not rows:
+                print("  (no tables found)")
+            else:
+                for (table_name,) in rows:
+                    print(f"  - {table_name}")
+
+        cur.close()
         conn.close()
+        print(f"\n{target_db.upper()} DB smoke test completed.\n")
+
     except Exception as e:
-        print("Modular test: Connection failed:", e)
+        print(f"\n{target_db.upper()} DB smoke test FAILED")
+        print("Error:", e)
+
 
 if __name__ == "__main__":
-    print("Starting modular database connection test...")
-    test_db_connection()
+    """
+    Run this file directly to manually test DB connections.
+
+    Examples (from your repo root, assuming this file is in test_scripts/):
+
+        python test_scripts/get_db_conn.py
+            -> tests MAIN DB by default
+
+        python test_scripts/get_db_conn.py main
+            -> explicitly tests MAIN DB
+
+        python test_scripts/get_db_conn.py test
+            -> tests TEST DB (using DB_TEST_CREDENTIALS)
+    """
+    # Choose which DB to test from CLI arg: "main" or "test"
+    arg = sys.argv[1].lower() if len(sys.argv) > 1 else "main"
+    print(f"Running smoke test for {arg.upper()} DB...")
+    smoke_test_connection(arg, list_tables=True)

--- a/etl/test_scripts/get_db_conn.py
+++ b/etl/test_scripts/get_db_conn.py
@@ -10,7 +10,25 @@ sys.path.append(
     )
 )
 
-from credentials import DB_CREDENTIALS, DB_TEST_CREDENTIALS
+try:
+    from credentials import DB_CREDENTIALS, DB_TEST_CREDENTIALS
+except ModuleNotFoundError:
+    # CI (and some environments) won't have credentials.py because it's gitignored.
+    DB_CREDENTIALS = {
+        "host": os.getenv("DB_HOST", "football-db.postgres.database.azure.com"),
+        "port": int(os.getenv("DB_PORT", "5432")),
+        "dbname": os.getenv("DB_NAME", "footysphere_db"),
+        "user": os.getenv("DB_USER", "football_pgadmin"),
+        "password": os.getenv("DB_PASSWORD", "Password"),
+    }
+
+    DB_TEST_CREDENTIALS = {
+        "host": os.getenv("DB_HOST", "football-db.postgres.database.azure.com"),
+        "port": int(os.getenv("DB_PORT", "5432")),
+        "dbname": os.getenv("DB_TEST_NAME", "footysphere_test_db"),
+        "user": os.getenv("DB_USER", "football_pgadmin"),
+        "password": os.getenv("DB_PASSWORD", "Password"),
+    }
 
 
 def get_db_connection(target_db: str = "main"):

--- a/frontend/src/pages/homePage/HomePage.jsx
+++ b/frontend/src/pages/homePage/HomePage.jsx
@@ -10,6 +10,7 @@ import LeagueModal from "./LeagueModal";
 
 import PopularLeagues from "./PopularLeagues";
 import TodaysMatches from "./TodaysMatches";
+import LeagueCountryFilter from "./LeagueCountryFilter";
 import News from "./News"; // ← NEW
 
 // Helper: try multiple endpoints safely
@@ -112,6 +113,8 @@ export default function HomePage() {
           loading={loadingLeagues}
           onViewMore={() => setShowLeagueModal(true)}
         />
+        
+        <LeagueCountryFilter apiBase={API} />
 
         <TodaysMatches
           matchesByLeague={matchesByLeague}

--- a/frontend/src/pages/homePage/LeagueCountryFilter.jsx
+++ b/frontend/src/pages/homePage/LeagueCountryFilter.jsx
@@ -1,0 +1,334 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { FaGlobeAmericas } from "react-icons/fa";
+
+import "./styles/popularLeagues.css";
+import "./styles/leagueCountryFilter.css";
+
+export default function LeagueCountryFilter({ apiBase }) {
+  const API = (apiBase || "").replace(/\/+$/, "");
+
+  const [countries, setCountries] = useState([]);
+  const [selectedCountry, setSelectedCountry] = useState(null);
+
+  const [leagues, setLeagues] = useState([]);
+  const [loadingCountries, setLoadingCountries] = useState(true);
+  const [loadingLeagues, setLoadingLeagues] = useState(false);
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [letter, setLetter] = useState("");
+  const inputRef = useRef(null);
+
+  // Keep leagues from getting cluttered if a country has many
+  const LEAGUE_PAGE_SIZE = 10;
+  const [leagueLimit, setLeagueLimit] = useState(LEAGUE_PAGE_SIZE);
+
+  // Fetch countries once (backend already returns alphabetical)
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        setLoadingCountries(true);
+        const res = await fetch(`${API}/countries`);
+        if (!res.ok) throw new Error("Failed to load countries");
+        const data = await res.json();
+
+        const list = (Array.isArray(data) ? data : [])
+          .map((x) => (x?.country ?? "").trim())
+          .filter(Boolean);
+
+        if (!cancelled) setCountries(list);
+      } catch (e) {
+        console.error(e);
+        if (!cancelled) setCountries([]);
+      } finally {
+        if (!cancelled) setLoadingCountries(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [API]);
+
+  // Default selected = first country (alphabetical)
+  useEffect(() => {
+    if (selectedCountry) return;
+    if (!countries.length) return;
+    setSelectedCountry(countries[0]);
+  }, [countries, selectedCountry]);
+
+  // Fetch leagues for selected country
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      if (!selectedCountry) {
+        setLeagues([]);
+        return;
+      }
+
+      try {
+        setLoadingLeagues(true);
+        const url = `${API}/leagues_by_country?country=${encodeURIComponent(
+          selectedCountry
+        )}`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error("Failed to load leagues");
+        const data = await res.json();
+
+        if (!cancelled) setLeagues(Array.isArray(data) ? data : []);
+      } catch (e) {
+        console.error(e);
+        if (!cancelled) setLeagues([]);
+      } finally {
+        if (!cancelled) setLoadingLeagues(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [API, selectedCountry]);
+
+  // Reset leagues pagination when changing country
+  useEffect(() => {
+    setLeagueLimit(LEAGUE_PAGE_SIZE);
+  }, [selectedCountry]);
+
+  // Top chips: first 9 (alphabetical from API)
+  const chipCountries = useMemo(() => countries.slice(0, 9), [countries]);
+
+  // More: everything after first 9
+  const moreCountries = useMemo(() => countries.slice(9), [countries]);
+
+  // Big list behavior (100+ countries)
+  const isLargeMore = moreCountries.length > 24;
+
+  const availableLetters = useMemo(() => {
+    const set = new Set();
+    for (const c of moreCountries) {
+      const ch = (c[0] || "").toUpperCase();
+      if (ch) set.add(ch);
+    }
+    return Array.from(set).sort();
+  }, [moreCountries]);
+
+  const filteredCountries = useMemo(() => {
+    let base = moreCountries;
+
+    if (letter) {
+      base = base.filter((c) => (c[0] || "").toUpperCase() === letter);
+    }
+
+    const q = query.trim().toLowerCase();
+    if (q) {
+      base = base.filter((c) => c.toLowerCase().includes(q));
+    }
+
+    // Don’t dump 100+ countries unless user filters
+    if (isLargeMore && !letter && !q) return [];
+
+    return base.slice(0, 120);
+  }, [moreCountries, letter, query, isLargeMore]);
+
+  const visibleLeagues = useMemo(
+    () => leagues.slice(0, leagueLimit),
+    [leagues, leagueLimit]
+  );
+
+  const canLoadMoreLeagues = leagues.length > leagueLimit;
+
+  const selectCountry = (c) => {
+    setSelectedCountry(c);
+    setPickerOpen(false);
+    setQuery("");
+    setLetter("");
+  };
+
+  const togglePicker = () => {
+    if (!moreCountries.length) return;
+
+    setPickerOpen((v) => {
+      const next = !v;
+
+      if (next) {
+        if (isLargeMore) setTimeout(() => inputRef.current?.focus(), 0);
+      } else {
+        setQuery("");
+        setLetter("");
+      }
+
+      return next;
+    });
+  };
+
+  // Keep “More” highlighted if selected country isn’t in top chips
+  const moreIsActive =
+    pickerOpen || (selectedCountry && !chipCountries.includes(selectedCountry));
+
+  return (
+    <section className="section-block league-country-filter">
+      <div className="section-header">
+        <div className="section-icon-box">
+          <FaGlobeAmericas className="section-icon" />
+        </div>
+        <h2 className="section-title">Browse Leagues</h2>
+      </div>
+
+      {/* Chips row */}
+      <div className="country-bar country-bar--wrap">
+        {loadingCountries ? (
+          <span className="muted">Loading…</span>
+        ) : (
+          <>
+            {chipCountries.map((c) => (
+              <button
+                key={c}
+                type="button"
+                className={`country-chip ${
+                  selectedCountry === c ? "country-chip--active" : ""
+                }`}
+                onClick={() => selectCountry(c)}
+              >
+                {c}
+              </button>
+            ))}
+
+            {/* Anchor so dropdown is positioned under the More button */}
+            <div className="more-anchor">
+              <button
+                type="button"
+                className={`country-chip country-chip--more ${
+                  moreIsActive ? "country-chip--active" : ""
+                }`}
+                onClick={togglePicker}
+                disabled={!moreCountries.length}
+              >
+                More
+              </button>
+
+              {pickerOpen && (
+                <div
+                  className={`more-dropdown ${isLargeMore ? "is-large" : "is-small"}`}
+                >
+                  {isLargeMore && (
+                    <>
+                      <input
+                        ref={inputRef}
+                        className="more-search"
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        placeholder="Search countries…"
+                        aria-label="Search countries"
+                      />
+
+                      <div className="more-alpha">
+                        <button
+                          type="button"
+                          className={`alpha-btn ${letter === "" ? "is-active" : ""}`}
+                          onClick={() => setLetter("")}
+                        >
+                          All
+                        </button>
+
+                        {availableLetters.map((ch) => (
+                          <button
+                            key={ch}
+                            type="button"
+                            className={`alpha-btn ${letter === ch ? "is-active" : ""}`}
+                            onClick={() => setLetter(ch)}
+                          >
+                            {ch}
+                          </button>
+                        ))}
+                      </div>
+                    </>
+                  )}
+
+                  <div className={`more-list ${isLargeMore ? "dense" : "compact"}`}>
+                    {filteredCountries.map((c) => (
+                      <button
+                        key={c}
+                        type="button"
+                        className={`more-pill ${
+                          selectedCountry === c ? "is-active" : ""
+                        }`}
+                        onClick={() => selectCountry(c)}
+                        title={c}
+                      >
+                        {c}
+                      </button>
+                    ))}
+
+                    {!filteredCountries.length && (
+                      <div className="more-empty muted">
+                        {isLargeMore
+                          ? "Type to search or pick a letter."
+                          : "No matches."}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Leagues results */}
+      {loadingLeagues && <p className="muted">Loading leagues…</p>}
+
+      {!loadingLeagues && selectedCountry && (
+        <>
+          <div className="leagues-grid leagues-grid--compact">
+            {visibleLeagues.map((lg) => {
+              const id = lg.id ?? lg.league_id;
+              const name = lg.name ?? lg.league_name;
+              const country = lg.country ?? lg.league_country;
+              const logo = lg.logo_url ?? lg.league_logo_url;
+
+              return (
+                <Link
+                  key={id}
+                  to={`/league/${id}`}
+                  className="league-card tile tile--interactive"
+                >
+                  <div className="league-logo-wrap">
+                    <img
+                      src={logo}
+                      alt={`${name} logo`}
+                      className="league-logo"
+                      loading="lazy"
+                    />
+                  </div>
+
+                  <div className="league-text">
+                    <h3>{name}</h3>
+                    <p>{country}</p>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+
+          {canLoadMoreLeagues && (
+            <button
+              type="button"
+              className="leagues-load-more"
+              onClick={() => setLeagueLimit((v) => v + LEAGUE_PAGE_SIZE)}
+            >
+              Show more leagues
+            </button>
+          )}
+
+          {!visibleLeagues.length && (
+            <p className="muted">No leagues found for {selectedCountry}.</p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/homePage/styles/leagueCountryFilter.css
+++ b/frontend/src/pages/homePage/styles/leagueCountryFilter.css
@@ -1,0 +1,216 @@
+/* Make sure dropdown isn't clipped by section styles */
+.league-country-filter{
+  position: relative;
+  overflow: visible;
+}
+
+/* =========================
+   Chips row
+========================= */
+.country-bar{
+  display:flex;
+  gap:.5rem;
+  align-items:center;
+  padding:.25rem 0 .4rem;
+  overflow: visible;
+}
+.country-bar--wrap{
+  flex-wrap: wrap;
+}
+
+.country-chip{
+  border:1px solid rgba(255,255,255,.12);
+  background: rgba(255,255,255,.06);
+  color: var(--text-200);
+  font-size:.78rem;
+  font-weight:750;
+  padding:.34rem .68rem;
+  border-radius:999px;
+  cursor:pointer;
+  white-space:nowrap;
+  transition: border-color .16s ease, background .16s ease, box-shadow .16s ease;
+}
+.country-chip:hover{
+  border-color: rgba(255,255,255,.22);
+  box-shadow: 0 0 0 3px rgba(255,255,255,.04);
+}
+.country-chip--active{
+  background: rgba(59,130,246,.22);
+  border-color: rgba(59,130,246,.45);
+  color:#fff;
+}
+.country-chip--more{
+  background: rgba(17,24,39,.55);
+}
+
+/* =========================
+   “More” dropdown (THIS is what removes clutter)
+   - doesn’t create a second row
+   - floats over content
+========================= */
+.more-anchor{
+  position: relative;
+  display: inline-flex;
+}
+
+.more-dropdown{
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 50;
+
+  width: min(720px, calc(100vw - 48px));
+  padding: .6rem .65rem;
+  border-radius: 16px;
+
+  background: rgba(14,20,30,.92);
+  border: 1px solid rgba(255,255,255,.10);
+
+  /* NO SHADOW / NO GLOW */
+  box-shadow: none;
+
+  /* optional: if you want it to look less “hazy” too */
+  backdrop-filter: none;
+}
+
+
+.more-dropdown.is-small{
+  width: fit-content;
+  max-width: min(720px, calc(100vw - 48px));
+  padding: .55rem .6rem;
+}
+
+/* Search */
+.more-search{
+  width: 100%;
+  background: rgba(255,255,255,.06);
+  border: 1px solid rgba(255,255,255,.10);
+  border-radius: 12px;
+  padding: .55rem .75rem;
+  color: var(--text-100);
+  outline:none;
+}
+.more-search::placeholder{
+  color: rgba(174,183,196,.85);
+}
+
+/* A–Z */
+.more-alpha{
+  margin-top: .45rem;
+  display:flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+}
+
+.alpha-btn{
+  border:1px solid rgba(255,255,255,.10);
+  background: rgba(255,255,255,.04);
+  color: var(--text-200);
+  font-size:.72rem;
+  font-weight:800;
+  border-radius: 10px;
+  padding: .25rem .45rem;
+  cursor:pointer;
+  transition: border-color .16s ease, background .16s ease, box-shadow .16s ease;
+}
+.alpha-btn:hover{
+  border-color: rgba(255,255,255,.22);
+  box-shadow: 0 0 0 3px rgba(255,255,255,.035);
+}
+.alpha-btn.is-active{
+  background: rgba(59,130,246,.18);
+  border-color: rgba(59,130,246,.40);
+  color:#fff;
+}
+
+/* List container
+   - no translate hover so nothing gets cut off
+   - padding:2px so glow never clips inside scroll
+*/
+.more-list{
+  margin-top: .45rem;
+  padding: 2px;
+  max-height: 240px;
+  overflow: auto;
+  padding-right: .2rem;
+}
+
+.more-dropdown.is-small .more-list{
+  margin-top: 0;
+}
+
+/* Small list = wrap pills naturally */
+.more-list.compact{
+  display:flex;
+  flex-wrap: wrap;
+  gap:.45rem;
+}
+
+/* Large list = dense grid, still scrollable */
+.more-list.dense{
+  display:grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap:.45rem;
+}
+
+/* Pills */
+.more-pill{
+  border:1px solid rgba(255,255,255,.10);
+  background: rgba(255,255,255,.05);
+  color: var(--text-200);
+  font-size:.78rem;
+  font-weight:750;
+  border-radius:999px;
+  padding: .34rem .68rem;
+  cursor:pointer;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  transition: border-color .16s ease, background .16s ease, box-shadow .16s ease;
+}
+.more-pill:hover{
+  border-color: rgba(255,255,255,.22);
+  box-shadow: 0 0 0 3px rgba(255,255,255,.035);
+}
+.more-pill.is-active{
+  background: rgba(59,130,246,.18);
+  border-color: rgba(59,130,246,.40);
+  color:#fff;
+  box-shadow: 0 0 0 3px rgba(59,130,246,.10);
+}
+
+.more-empty{
+  padding:.35rem .2rem;
+}
+
+/* =========================
+   League grid (don’t stretch into banners)
+========================= */
+.leagues-grid--compact{
+  margin-top: .6rem;
+}
+
+.leagues-grid.leagues-grid--compact{
+  grid-template-columns: repeat(auto-fill, minmax(320px, 420px));
+  justify-content: start;
+}
+
+/* Load more leagues */
+.leagues-load-more{
+  margin-top: .55rem;
+  border: 1px solid rgba(255,255,255,.10);
+  background: rgba(255,255,255,.05);
+  color: var(--text-200);
+  font-weight: 800;
+  font-size: .8rem;
+  padding: .5rem .75rem;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color .16s ease, background .16s ease, box-shadow .16s ease;
+}
+.leagues-load-more:hover{
+  border-color: rgba(255,255,255,.22);
+  box-shadow: 0 0 0 3px rgba(255,255,255,.035);
+}


### PR DESCRIPTION
Backend:
Added /countries and /leagues_by_country endpoints to support filtering leagues by country
Added integration tests (direct endpoint tests + HTTP tests) against a seeded test database
Added a lightweight test schema setup (backend/tests/schema_test.sql) for CI runs
Updated backend CI workflow to spin up Postgres, apply schema, and run the integration tests
Updated ETL test DB connection helper to support the test environment cleanly

Frontend:
Added a LeagueCountryFilter component and styling
Updated the Home page to integrate the country filter UI

How to test:
Frontend: load the Home page and use the country filter to confirm leagues update correctly
Backend: hit /countries and /leagues_by_country?country=England and verify expected results

CI: verify backend-ci and frontend-ci checks pass on the PR